### PR TITLE
AP unwanted messages

### DIFF
--- a/topics-and-advance-readings/README.md
+++ b/topics-and-advance-readings/README.md
@@ -30,4 +30,11 @@ really, read as much as you can!)
 
 [list of topics and papers goes here.]
 
+### ActivityPub / Spam
+
+* [Keeping Unwanted Messages off the Fediverse)(./ap-unwanted-messages.md)
+  * By [Serge Wroclawski](http://blog.emacsen.net) with advice and ideas by [Christopher Lemmer Webber](https://dustycloud.org)
+  * "A collection of techniques to keep unwanted messages (spam, phishing, hate speech) off the Fediverse, with a focus on OCAP and WoT.
+  * #activitypub #spam #wot #ocap
+
 ## Alphabetical Listing

--- a/topics-and-advance-readings/ap-unwanted-messages.md
+++ b/topics-and-advance-readings/ap-unwanted-messages.md
@@ -1,30 +1,30 @@
 
 # Table of Contents
 
-1.  [Introduction](#orged105b0)
-2.  [ActivityPub Overview](#org0afa829)
-3.  [Proposed Suggestions](#orgda828b1)
-    1.  [Enhanced Privacy of Followers/Following Collection](#org3c24fd4)
-    2.  [Strict Protocol Adherence](#orgaed1764)
-    3.  [Object-Capabilities Based Inboxes](#orga30d83f)
-    4.  [MultiBox](#orgce9d54a)
-    5.  [Multiple Inboxes/Message Sorting](#org16f16a6)
-    6.  [Sender Identification and Pet Names](#org8370e97)
-    7.  [Blacklists](#org6560321)
-    8.  [Closing the Relay Hole](#org8998be3)
-    9.  [Content Based Filtering](#org4f3df99)
-    10. [Whitelists](#org62e755c)
-    11. [Message Flagging/Sorting](#org942dfbd)
-    12. [Postage](#orgc19ec55)
-    13. [Bounce Messages](#org6794f06)
-    14. [Promises](#orga78d9a1)
-4.  [Combining Techniques](#org8919757)
-5.  [A Note for ActivityPub Node Operators](#org341a92e)
-6.  [Conclusion](#org18eb43c)
+1.  [Introduction](#org0cb1b2e)
+2.  [ActivityPub Overview](#orgef57722)
+3.  [Proposed Suggestions](#org41786bf)
+    1.  [Enhanced Privacy of Followers/Following Collection](#org6c32426)
+    2.  [Strict Protocol Adherence](#orgcf764cd)
+    3.  [Object-Capabilities Based Inboxes](#org86f27df)
+    4.  [MultiBox](#orgddd1c45)
+    5.  [Multiple Inboxes/Message Sorting](#org7ca275c)
+    6.  [Sender Identification and Pet Names](#org63d8acf)
+    7.  [Blacklists](#orgaddb0f2)
+    8.  [Closing the Relay Hole](#orgcc3a6dc)
+    9.  [Content Based Filtering](#orge8cb386)
+    10. [Whitelists](#orged71066)
+    11. [Message Flagging/Sorting](#orgda2286c)
+    12. [Postage](#org4aa6313)
+    13. [Bounce Messages](#org87447fe)
+    14. [Promises](#orgda719ec)
+4.  [Combining Techniques](#orgd688634)
+5.  [A Note for ActivityPub Node Operators](#org9e2ea82)
+6.  [Conclusion](#orgad81b64)
 
 
 
-<a id="orged105b0"></a>
+<a id="org0cb1b2e"></a>
 
 # Introduction
 
@@ -59,7 +59,7 @@ multiple domains of messages, regardless of content or whether the messages are
 meant for a public or private audience.
 
 
-<a id="org0afa829"></a>
+<a id="orgef57722"></a>
 
 # ActivityPub Overview
 
@@ -93,12 +93,12 @@ Actor Object. Requests made on behalf of that actor are then signed using the
 Actor's private key and may be verified against its public key.
 
 
-<a id="orgda828b1"></a>
+<a id="org41786bf"></a>
 
 # Proposed Suggestions
 
 
-<a id="org3c24fd4"></a>
+<a id="org6c32426"></a>
 
 ## Enhanced Privacy of Followers/Following Collection
 
@@ -112,7 +112,7 @@ be disclosed to a third party or only be disclosed insofar as it related to the
 actor making the request.
 
 
-<a id="orgaed1764"></a>
+<a id="orgcf764cd"></a>
 
 ## Strict Protocol Adherence
 
@@ -144,7 +144,7 @@ Nonetheless, we mention this method because it has been so effective in email,
 and thus may be something to evaluate again in the future.
 
 
-<a id="orga30d83f"></a>
+<a id="org86f27df"></a>
 
 ## Object-Capabilities Based Inboxes
 
@@ -159,7 +159,7 @@ Without delving too far into the theory of object capabilities, we can imagine
 that the ability to send a message from one Actor to another is an action that
 we can grant explicit access to similarly to the way that access is granted to
 an API in a computer system. In order to be able to send a message to the
-receipient, the recipient must first provide the sender with a *capability* to
+recipient, the recipient must first provide the sender with a *capability* to
 do so. This capability can be represented as a long randomly generated string.
 Its length and randomness make it impractical to guess and thus (in OCAP
 parlance) unforgeable.
@@ -172,7 +172,7 @@ This act of the sender handing out capabilities may be done in a number of
      "type": "Inbox",
      "to": ["https://chatty.example/ben/"],
      "attributedTo": "https://social.example/alyssa/",
-     "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj]
+     "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
 
 In our example, we show multiple inboxes being delivered. As part of the Object
 Capabilities model, these capabilities are transferable, which would allow one
@@ -193,7 +193,7 @@ endpoint as discussed previously. In such cases, a server would need to
 retrieve a new Inbox for an Actor as needed.
 
 
-<a id="orgce9d54a"></a>
+<a id="orgddd1c45"></a>
 
 ## MultiBox
 
@@ -217,7 +217,7 @@ separated values<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup>.
 This has two advantages over Shared Inbox. Used on its own, it eliminates the
 vulnerability mentioned previously whereby recipients to a message do not need
 to be listed. If this proposal is adopted alongside the Object-Capabilities
-Based Inbox proposal ([3.3](#orga30d83f)), the
+Based Inbox proposal ([3.3](#org86f27df)), the
 advantages multiply as we also gain the ability to appropriately filter
 incoming messages according to the criteria set out by the specific Inboxes, as
 well as letting us know the origin of each Inbox.
@@ -236,7 +236,7 @@ This would limit the number of per message recipients, though this limitation
  `MultiBox` object encapsulating the `Audience` field and the ~Activity.
 
 
-<a id="org16f16a6"></a>
+<a id="org7ca275c"></a>
 
 ## Multiple Inboxes/Message Sorting
 
@@ -255,12 +255,12 @@ protocol dictated in the ActivityPub standard.<sup><a id="fnr.13" class="footref
 
 A variety of techniques could be employed when sorting messages, including but
 not limited to the content based filtering techniques described in previous
-sections about filtering based on message content ([3.9](#org4f3df99)) or
-using OCAP Inboxes ([3.3](#orga30d83f)) described in this
+sections about filtering based on message content ([3.9](#orge8cb386)) or
+using OCAP Inboxes ([3.3](#org86f27df)) described in this
 whitepaper.
 
 
-<a id="org8370e97"></a>
+<a id="org63d8acf"></a>
 
 ## Sender Identification and Pet Names
 
@@ -272,7 +272,7 @@ literature as either *Joe Jobbing* or *Phishing*.
 
 In Email, verification is largely achieved by verifying that the email server
 is trusted for the domain which it purports to deliver email, often through an
-out of band technique, often involving DNS, such as SPF<sup><a id="fnr.14" class="footref" href="#fn.14">14</a></sup> or DMIM<sup><a id="fnr.15" class="footref" href="#fn.15">15</a></sup>.
+out of band technique, often involving DNS, such as SPF<sup><a id="fnr.14" class="footref" href="#fn.14">14</a></sup> or DKIM<sup><a id="fnr.15" class="footref" href="#fn.15">15</a></sup>.
 
 In ActivityPub, sender identification is performed at the Actor level using the
 HTTP Signatures.<sup><a id="fnr.4.100" class="footref" href="#fn.4">4</a></sup> With this extension, each Actor has a public and private
@@ -294,7 +294,7 @@ indicating that the communication is more likely to be useful.
 
 We recognize that this proposal may seem in contrast to the previous proposal
 of not disclosing connections to third parties as described in the section on
-improving privacy of Follower/Following Collections ([3.1](#org3c24fd4)), but the two can operate in tandem by making
+improving privacy of Follower/Following Collections ([3.1](#org6c32426)), but the two can operate in tandem by making
 the ability to find a connection to your followers be a query, rather than a
 publicly available list. We could further enhance the security of this by
 adding additional restrictions onto the query functionality such as rate
@@ -306,7 +306,7 @@ believe that this would require further examination in order to be done in a
 way that protects a user's social graph.
 
 
-<a id="org6560321"></a>
+<a id="orgaddb0f2"></a>
 
 ## Blacklists
 
@@ -320,7 +320,7 @@ In ActivityPub an individual Actor or server administrator may choose to create
 a custom blocklist, but there is currently no standardized way to distribute or
 share blocklists. We propose that this be explored further, though cautiously
 by allowing Actors to query each other's either mute or block lists through a
-mechanism similar to the proposal described in the section on Pet Names ([3.6](#org8370e97)).
+mechanism similar to the proposal described in the section on Pet Names ([3.6](#org63d8acf)).
 
 Actors who have agreed to peer with each other in regards to shared mute or
 block lists will be given an additional property in their actor object
@@ -347,7 +347,7 @@ miss out on messages that they might wish to recieve. The analogy of adblocking
 software is often used by those supporting this type of proposal, but in
 ad-blocking, it is possible to disable the software selectively when the
 functionality of a website does not work. With blocklists, unless they are
-paired with another proposal, such as the one about multiple inboxes ([3.5](#org16f16a6)), they may have the consequence of breaking federation.
+paired with another proposal, such as the one about multiple inboxes ([3.5](#org7ca275c)), they may have the consequence of breaking federation.
 
 Thirdly, the mechanism described precludes the ability to easily remove a
 block. If a block is removed, there is no mechanism that allows those who have
@@ -362,7 +362,7 @@ unwanted messages, unless we can address the concerns raised above, we cannot
 endorse their deployment.
 
 
-<a id="org8998be3"></a>
+<a id="orgcc3a6dc"></a>
 
 ## Closing the Relay Hole
 
@@ -400,7 +400,7 @@ reply without moderation is given a new Inbox corresponding to this added
 capability.
 
 
-<a id="org4f3df99"></a>
+<a id="orge8cb386"></a>
 
 ## Content Based Filtering
 
@@ -426,7 +426,7 @@ in creating training models that work well based on community standards of
 interest and behavior.
 
 
-<a id="org62e755c"></a>
+<a id="orged71066"></a>
 
 ## Whitelists
 
@@ -447,7 +447,7 @@ Such whitelists are difficult to curate and more importantly, break the spirit
 of communication that as at the heart of the protocol.
 
 
-<a id="org942dfbd"></a>
+<a id="orgda2286c"></a>
 
 ## Message Flagging/Sorting
 
@@ -468,7 +468,7 @@ that it could be handled more easily, or possibly allowing those messages to be
 screened further.
 
 
-<a id="orgc19ec55"></a>
+<a id="org4aa6313"></a>
 
 ## Postage
 
@@ -504,7 +504,7 @@ encourage any implementation of this technique to be used sparingly and only on
 the first message of a new sender, rather than on all messages.
 
 
-<a id="org6794f06"></a>
+<a id="org87447fe"></a>
 
 ## Bounce Messages
 
@@ -520,7 +520,7 @@ client, allowing an ActivityPub server administrator the opportunity to see why
 messages are failing and take appropriate action.
 
 
-<a id="orga78d9a1"></a>
+<a id="orgda719ec"></a>
 
 ## Promises
 
@@ -531,11 +531,11 @@ status of message delivery which could then be queried at a later time to
 determine if the message was delivered successfully or rejected.
 
 These Promise statuses could use the same error codes as discussed in the
-section on Bounce Messages ([3.13](#org6794f06)) but not be required to keep the
+section on Bounce Messages ([3.13](#org87447fe)) but not be required to keep the
 HTTP connection open during the determination of message suitability.
 
 
-<a id="org8919757"></a>
+<a id="orgd688634"></a>
 
 # Combining Techniques
 
@@ -545,11 +545,11 @@ MultiBox used in conjunction with Object Capabilities Inboxes allows for
 per-Actor filtering to be performed more easily. OCAP Inboxes may also be
 granted which allow a sender to bypass other filters, acting effectively as an
 Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
-explored ACL vs OCAP inReplyTo functionality in [3.8](#org8998be3), and
+explored ACL vs OCAP inReplyTo functionality in [3.8](#orgcc3a6dc), and
 either of these techniques could be combined with content analysis.
 
 
-<a id="org341a92e"></a>
+<a id="org9e2ea82"></a>
 
 # A Note for ActivityPub Node Operators
 
@@ -570,7 +570,7 @@ We have not addressed this issue in this paper but believe that the topic
 deserves further research.
 
 
-<a id="org18eb43c"></a>
+<a id="orgad81b64"></a>
 
 # Conclusion
 
@@ -582,7 +582,7 @@ Capabilities Inboxes allows for per-Actor filtering to be performed more
 easily. OCAP Inboxes may also be granted which allow a sender to bypass other
 filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
 may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
-[3.8](#org8998be3), and either of these techniques could be combined with
+[3.8](#orgcc3a6dc), and either of these techniques could be combined with
 content analysis.
 
 We believe that the problem of unwanted messages is addressable and we look

--- a/topics-and-advance-readings/ap-unwanted-messages.md
+++ b/topics-and-advance-readings/ap-unwanted-messages.md
@@ -1,0 +1,637 @@
+
+# Table of Contents
+
+1.  [Introduction](#org5add05a)
+2.  [ActivityPub Overview](#org1929d17)
+3.  [Proposed Solutions](#org62c38c0)
+    1.  [Enhanced Privacy of Followers/Following Collection](#org088cba8)
+    2.  [Strict Protocol Adherence](#orge014dfd)
+    3.  [Object-Capabilities Based Inboxes](#org2e21bea)
+    4.  [MultiBox](#org01e5593)
+    5.  [Multiple Inboxes/Message Sorting](#org5e8e38a)
+    6.  [Sender Identification and Pet Names](#org6ab3d8a)
+    7.  [Blacklists](#orgff8373c)
+        1.  [Caution and Conclusions](#org5e44ee7)
+    8.  [Closing the Relay Hole](#orga9aeacc)
+    9.  [Content Based Filtering](#org912102f)
+    10. [Whitelists](#org21c8b9f)
+    11. [Message Flagging/Sorting](#org1920bd4)
+    12. [Postage](#orgdd78757)
+    13. [Bounce Messages](#org8fee336)
+    14. [Promises](#org6d9b938)
+4.  [Combining Techniques](#org559f6a7)
+5.  [A Note for ActivityPub Node Operators](#org0f0532f)
+6.  [Conclusion](#orgcb16a86)
+7.  [Endnotes](#org00aa5bc)
+
+
+
+<a id="org5add05a"></a>
+
+# Introduction
+
+Unwanted messages are a challenge for all public communication systems. On a
+federated network without a central form of control, the challenge is extended
+to allowing for free communication between parties without a central means of
+control while at the same time preventing undesired or harmful messages.
+
+ActivityPub<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is a W3C standard protocol designed to facilitate social
+networks. The aggregate name for systems that use the ActivityPub is the
+Fediverse. As of the time of publication, there are approximately three million
+user accounts on the Fediverse spread across approximately 5,400 nodes.<sup><a id="fnr.2" class="footref" href="#fn.2">2</a></sup>
+Despite this large number, unwanted messages have not yet become a widespread
+problem. It seems inevitable that given the size and breath of the Fediverse,
+along with its decentralized architecture that the introduction of unwanted
+messages is possibly inevitable.
+
+What exactly constitutes unwanted messages will vary from person and community
+but we generally feel these messages fall into one or more of the following
+categories: Unsolicited commercial messages (spam), messages designed to commit
+fraud (scams, phishing), messages designed to harm or inflame (trolling),
+messages designed to harm, intimidate or coerce (bullying), abusive or
+threatening speech against a particular group (hate speech), messages
+containing deliberate disinformation (fake news), or messages of an
+inappropriate nature for community standards (eg violence or pornography). We
+do not define these terms further nor do we believe in a universal enforcement
+of any one set of community standards, instead we rely on each node and
+community to define these standards for themselves.
+
+The techniques described in this paper are generalized and could be used across
+multiple domains of messages, regardless of content or whether the messages are
+meant for a public or private audience.
+
+
+<a id="org1929d17"></a>
+
+# ActivityPub Overview
+
+ActivityPub is an HTTP based messaging system that allows for seamless cross
+server communication (aka federation). In ActivityPub, individual accounts
+called `Actors` are addressed by unique URN identifiers. Messages between
+Actors are serialized using an extension of the Activity Streams
+specification<sup><a id="fnr.3" class="footref" href="#fn.3">3</a></sup>. These messages are called Activities. Each Activity is
+composed of three parts:: The `Actor` originating the Activity, an `Activity
+Type` representing the action being taken and an `Object`. Objects are the core
+type in ActivityPub and may represent any noun in the system. Activities and
+Objects are referenced by URN as unique identifiers. Activities also have an
+audience field, which is a list of Actors which should have access to the
+Activity.
+
+Actor to Actor communication vaguely resembles email. Each `Actor`'s URN
+resolved to their `Actor Object` which specifies that messages destined to a
+specific Actor be delivered to its `Inbox`, a URN that is meant to receive such
+messages from external parties. ActivityPub also specifies an `Outbox` where
+outgoing messages are posted in a manner similar to RSS/Atom feeds, but using
+the Activity Streams vocabulary and reliant on authentication to ensure
+messages are only seen by those who have authority to do so. In addition to
+these delivery mechanisms, ActivityPub also specifies an optional `sharedInbox`
+where either multiple actors may be listed explicitly or where messages to
+multiple recipients may be interpreted by the receiving server implicitly.
+
+While not directly part of the standard, HTTP Signatures<sup><a id="fnr.4" class="footref" href="#fn.4">4</a></sup> are most
+commonly used with ActivityPub as the authentication mechanism. Actors have a
+generated keypair and their public keys are displayed on the aforementioned
+Actor Object. Requests made on behalf of that actor are then signed using the
+Actor's private key and may be verified against its public key.
+
+
+<a id="org62c38c0"></a>
+
+# Proposed Solutions
+
+
+<a id="org088cba8"></a>
+
+## Enhanced Privacy of Followers/Following Collection
+
+One of the tools of spammers is to collect as many contacts as possible. For a
+sophisticated attacker, the connections between contacts could be used to
+violate someone's privacy or as part of a sophisticated phishing or scamming
+attempt. Due to these and other concerns over sensitive information leaking to
+third parties, we suggest that `Followers` and `Following` collections not
+generally be made public. Instead, such private information should either never
+be disclosed to a third party or only be disclosed insofar as it related to the
+actor making the request.
+
+
+<a id="orge014dfd"></a>
+
+## Strict Protocol Adherence
+
+Postel's law states that a protocol implementer should be strict in what they
+send and liberal in what they accept.<sup><a id="fnr.5" class="footref" href="#fn.5">5</a></sup>. At the same time, email operators
+have found that many spammers' servers do not adhere strictly to the SMTP
+protocol. As an example, many mail servers lack a Forward-Confirmed Reverse DNS
+record<sup><a id="fnr.6" class="footref" href="#fn.6">6</a></sup> or send a HELO/EHLO that is not a fully qualified domain name or
+does not match the sender<sup><a id="fnr.7" class="footref" href="#fn.7">7</a></sup>. Many such servers also lack the ability to
+retry messages in the case of temporary failure, a situation that is utilized
+in greylisting<sup><a id="fnr.8" class="footref" href="#fn.8">8</a></sup>. Because of this pattern of non-compliance, one common
+technique to reduce spam in email is to find the areas of the protocol that are
+commonly skipped by spammers and either block access or restrict access based
+on non-compliance.
+
+It remains an open question on whether ActivityPub operator should take the
+same approach regarding federating with other ActivityPub servers. We do not
+believe that at this time such an approach is necessary or desirable. The
+approach of being strict in what one accepts from other servers was born out of
+necessity by email operators who found correlations between poor
+implementations and unwanted messages. While these correlations are undeniable,
+they are not causal nor directly associated except in that requiring strict
+adherence raised the bar for all email administrators, making it more
+challenging to run a mail server. Especially as it relates to PTR records, this
+prevented anyone who was not directly in a business relationship with their
+upstream provider to be able to operate a mail server. We do not believe that
+all ActivityPub servers should be required to keep to such strict standards.
+Nonetheless, we mention this method because it has been so effective in email,
+and thus may be something to evaluate again in the future.
+
+
+<a id="org2e21bea"></a>
+
+## Object-Capabilities Based Inboxes
+
+As per the ActivityPub specification, every `Actor` is required to have an
+associated `Inbox`. In most ActivityPub implementations, an Actor's inbox is
+simply a URL endpoint specific to the actor, e.g.
+`https://example.com/bob/inbox`. While convenient, we propose that servers
+should be using Object Capabilities model by which Inboxes are a capability
+handed out by a server.
+
+Without delving too far into the theory of object capabilities, we can imagine
+that the ability to send a message from one Actor to another is an action that
+we can grant explicit access to similarly to the way that access is granted to
+an API in a computer system. In order to be able to send a message to the
+receipient, the recipient must first provide the sender with a *capability* to
+do so. This capability can be represented as a long randomly generated string.
+Its length and randomness make it impractical to guess and thus (in OCAP
+parlance) unforgeable.
+
+This act of the sender handing out capabilities may be done in a number of
+ ways, though we suggest that offering a new Inbox could be performed as a new
+ Activity, for example:
+
+    {"@context": "...",
+     "type": "Inbox",
+     "to": ["https://chatty.example/ben/"],
+     "attributedTo": "https://social.example/alyssa/",
+     "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj]
+
+In our example, we show multiple inboxes being delivered. As part of the Object
+Capabilities model, these capabilities are transferable, which would allow one
+actor to send an inbox capability to another actor, for example in a situation
+where the recipient is a trusted party. 
+
+If one Inbox becomes abused, we are able to trace back to exactly when and for
+who the Inbox was generated. We are also able to revoke the Inbox, stopping any
+future requests to it. An HTTP request sent to an expired Inbox should ideally
+result in an HTTP 410 (Gone)<sup><a id="fnr.9" class="footref" href="#fn.9">9</a></sup>, alerting the sending to the unavailability
+of the inbox and prompting it to request a new one if it wishes to resume
+communication.
+
+The OCAP Inbox model as described in this proposal would require little or no
+changes to existing deployed ActivityPub servers except where such servers are
+not prepared to accept a non-success (200) result when posting to an HTTP
+endpoint as discussed previously. In such cases, a server would need to
+retrieve a new Inbox for an Actor as needed.
+
+
+<a id="org01e5593"></a>
+
+## MultiBox
+
+`Shared Inbox`<sup><a id="fnr.10" class="footref" href="#fn.10">10</a></sup> provides the ability for server to server communication
+traffic to be reduced from R requests, where R is the number of recipients, to
+a single HTTP request. This is a desirable property as it reduces the amount of
+HTTP round trips for both the sender and receiver. Unfortunately the design of
+Shared Inboxes as described in the ActivityPub specification makes it very easy
+for a spammer to abuse the system by not requiring explicit delivery
+recipients. We propose an alternative to Shared Inbox called MultiBox that
+keeps the desirable properties of Shared Inbox while protecting against
+scenarios in which the sender uses Shared Inbox to "spam" a server.
+
+Like Shared Inbox, MultiBox consists of a single HTTP endpoint for multiple
+Actors. Unlike Shared Inbox, in a MultiBox request, each recipient is
+explicitly listed *by Inbox*, requiring both the knowledge of the Actor and a
+corresponding Inbox for that actor. This information is transmitted through the
+use of an HTTP header `Audience` where each Inbox is listed using comma
+separated values<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup>.
+
+This has two advantages over Shared Inbox. Used on its own, it eliminates the
+vulnerability mentioned previously whereby recipients to a message do not need
+to be listed. If this proposal is adopted alongside the [3.3](#org2e21bea) proposal, the advantages multiply as we also gain the ability to
+appropriately filter incoming messages according to the criteria set out by the
+specific Inboxes, as well as letting us know the origin of each Inbox. 
+
+For the sender, the additional computing resources required to send a MultiBox
+request are minimal, but doing so would make mass-messages expensive for
+senders wishing to abuse the system.
+
+One open question on this proposal is that if we use the HTTP header `Audience`
+to store the list of recipients, this may result in a limitation. HTTP header
+sizes are not explicitly capped at the protocol level but implementations often
+cap them at different lengths- 4Kb for the Nginx web server or 8Kb for Apache.
+
+This would limit the number of per message recipients, though this limitation
+ would rarely be reached. An alternative to this proposal would be a new
+ `MultiBox` object encapsulating the `Audience` field and the ~Activity.
+
+
+<a id="org5e8e38a"></a>
+
+## Multiple Inboxes/Message Sorting
+
+The ActivityPub protocol specifies an `Inbox` collection<sup><a id="fnr.12" class="footref" href="#fn.12">12</a></sup> to store
+incoming messages for the Actor. This functions similarly to the common Email
+Inbox where by default, messages arrive. As thinking regarding email has
+evolved, automatic message sorting has been employed using either actual
+folders or tagging mechanisms. These same techniques could be applied to
+ActivityPub, whereby a message could be placed in an Inbox collection
+corresponding to sorting rules.
+
+This extension to the ActivityPub protocol would not have to be visible to any
+external entities (ie not accessible through the Server-To-Server
+communication) but only through the Client to Server (C2S) communication
+protocol dictated in the ActivityPub standard.<sup><a id="fnr.13" class="footref" href="#fn.13">13</a></sup>
+
+A variety of techniques could be employed when sorting messages, including but
+not limited to the content based filtering techniques described in [3.9](#org912102f) or using [3.3](#org2e21bea) mechanisms described
+in this whitepaper.
+
+
+<a id="org6ab3d8a"></a>
+
+## Sender Identification and Pet Names
+
+One of the most critical components of reducing unwanted messages is the
+identification of the sender of a message. Without verification, a sender may
+use their ability to impersonate someone else for a number of purposes, from
+spamming, to bypassing security or scamming, often referred to in the
+literature as either *Joe Jobbing* or *Phishing*.
+
+In Email, verification is largely achieved by verifying that the email server
+is trusted for the domain which it purports to deliver email, often through an
+out of band technique, often involving DNS, such as SPF<sup><a id="fnr.14" class="footref" href="#fn.14">14</a></sup> or DMIM<sup><a id="fnr.15" class="footref" href="#fn.15">15</a></sup>.
+
+In ActivityPub, sender identification is performed at the Actor level using the
+HTTP Signatures.<sup><a id="fnr.4.100" class="footref" href="#fn.4">4</a></sup> With this extension, each Actor has a public and private
+keypair. The public key of an Actor may be retrieved by retrieving its Actor
+Object, a JSON-LD object retrievable by HTTP. Since ActivityPub requires Actor
+object lookups as part of normal message deliver, this is adds only a minimal
+amount of additional work on the receiver's part. Each message sent on behalf
+of an Actor is signed at the HTTP level by this key, which can then be verified
+by the receiving server for authenticity.
+
+We propose to extend this validation with a second layer of identity validation
+through the use of Pet Names. The Pet Names proposal presented in Rebooting Web
+of Trust 2018<sup><a id="fnr.16" class="footref" href="#fn.16">16</a></sup> has a secondary property of being able to be used as
+simplified trust mechanism. When a sender would like to make contact with a
+receiver, the receiver checks its neighbors (Followers or Following) for a pet
+name for this sender. If a neighbor has decided to give this sender a Pet Name,
+then we know that there is some level of communication between them, thereby
+indicating that the communication is more likely to be useful.
+
+We recognize that this proposal may seem in contrast to the previous proposal
+of not disclosing connections to third parties as described in [3.1](#org088cba8), but the two can operate in tandem by making
+the ability to find a connection to your followers be a query, rather than a
+publicly available list. We could further enhance the security of this by
+adding additional restrictions onto the query functionality such as rate
+limiting queries.
+
+We further recognize that this is not a full Web of Trust system in that webs
+of trust extend beyond one hop. It would be possible do so here as well, but we
+believe that this would require further examination in order to be done in a
+way that protects a user's social graph.
+
+
+<a id="orgff8373c"></a>
+
+## Blacklists
+
+A blacklist is a list or searchable collection of entities which should be
+distrusted. Blacklists are widely used by many email administrators to prevent
+email originating from one or more types of sources that they distrust, such as
+mail servers residing on consumer grade Internet connections or mail servers
+that have been known to send spam recently.
+
+In ActivityPub an individual Actor or server administrator may choose to create
+a custom blocklist, but there is currently no standardized way to distribute or
+share blocklists. We propose that this be explored further, though cautiously
+by allowing Actors to query each other's either mute or block lists through a
+mechanism similar to the proposal described in [3.6](#org6ab3d8a).
+
+Actors who have agreed to peer with each other in regards to shared mute or
+block lists will be given an additional property in their actor object
+corresponding to a query endpoint for their blocklists, thus creating
+functionality where these lists can be shared between actors. These blocklists
+may contain either actor level or server level bans, and could additionally be
+shared between server administrators.
+
+
+<a id="org5e44ee7"></a>
+
+### Caution and Conclusions
+
+We believe that while blocklists may be effective in addressing some types of
+unwanted messages, particularly offensive speech, that they carry with them a
+number of caveats that give us pause in wholeheartedly endorsing this
+mechanism.
+
+Firstly, should a malicious party gain access to a blocklist, this could
+potentially create a situation in the originator would be made a target for
+attack. We believe that using a query service, rather than a list, mitigates
+this concern somewhat, but it would be possible for an a malicious party to
+covertly build up such a list and use it to create a list of targets.
+
+Secondly, we are concerned that the transitive properties of block lists may
+have unintended consequences or be used as a vector for attack or denial of
+service. If services adopt each other's blocklists without review, they may
+miss out on messages that they might wish to recieve. The analogy of adblocking
+software is often used by those supporting this type of proposal, but in
+ad-blocking, it is possible to disable the software selectively when the
+functionality of a website does not work. With blocklists, unless they are
+paired with another proposal, such as [3.5](#org5e8e38a), they
+may have the consequence of breaking federation.
+
+Thirdly, the mechanism described precludes the ability to easily remove a
+block. If a block is removed, there is no mechanism that allows those who have
+previously queried the blocklist to be notified. This problem is made worse if
+blocklists are transitive. It would be possible to replace a query based
+mechanism with a subscription based mechanism, but doing so would be subject to
+the concern raised previously about blocklists being used to target
+individuals.
+
+While we believe blocklists may be an effective strategy to block some types of
+unwanted messages, unless we can address the concerns raised above, we cannot
+endorse their deployment.
+
+
+<a id="orga9aeacc"></a>
+
+## Closing the Relay Hole
+
+Message Relaying involves sending a a message on behalf of another entity.
+Message relaying is common in Store-and-Forward network designs. In Email, it
+was common for servers to be offline some or most of the time, requiring that
+other servers acted as relays, either sending or accepting mail on their behalf
+cooperatively. In time, spammers began abusing these servers in order to send
+messages on their behalf. Because of this, many mail servers block "Open Mail
+Relays".
+
+In ActivityPub, message relaying is performed in accordance with Section 7.1.2
+of the ActivityPub specification<sup><a id="fnr.11.100" class="footref" href="#fn.11">11</a></sup> in order to mitigate the "Ghost Replies"
+problem, where a rely to a message is not seen by everyone watching that thread
+because the replier does not send the message to everyone that the original
+sender did. Unfortunately this also opens up replies as a vector of abuse in
+that a malicious sender may simply reply to an existing message, at which point
+the sender of the original message will relay the reply to all their Followers
+and any other audience of message.We suggest two solutions to this problem, one
+using traditional Access Control Lists and the other using the Object
+Capabilities Inbox proposal.
+
+An Access Control Method solution would allow for the recipient of a
+`inReplyTo` activity to be presented with a moderator queue of Activities in
+reply to their own, which they then may act on. If they accept the reply, the
+recipient will then send messages on behalf of the sender to their Followers.
+The recipient Actor may also decide on a policy regarding future replies from
+the same actor. For example, they may decide that future messages from that
+Actor need not be moderated, effectively granting them access to the relay
+functionality.
+
+An alternative method using the OCAP model would be to treat replies as a
+capability provided to by some Inboxes. An Actor who is then granted access to
+reply without moderation is given a new Inbox corresponding to this added
+capability.
+
+
+<a id="org912102f"></a>
+
+## Content Based Filtering
+
+While the other methods of message filtering address external signifiers of
+unwanted messages, content-based filtering looks directly at content of the
+messages themselves, either by lists of common terms found in unwanted
+messages, by evaluating the probability of messages being unwanted or by
+looking for other signifiers such as messages that appear to be phishing
+attempts.
+
+Content based filtering can take many forms, from simple rule based filters, to
+Baysean text analysis<sup><a id="fnr.17" class="footref" href="#fn.17">17</a></sup>, sentiment analysis or even more complex image
+classification.
+
+An exciting area of further exploration may be the use of Federated
+Learning<sup><a id="fnr.18" class="footref" href="#fn.18">18</a></sup>, whereby training can be performed in a way that allows
+individual data to be kept private but the results may be shared and built
+upon.
+
+We offer no specific technique or method for this suggestion but do think that
+the benefits of existing "theme based" ActivityPub services may be beneficial
+in creating training models that work well based on community standards of
+interest and behavior.
+
+
+<a id="org21c8b9f"></a>
+
+## Whitelists
+
+Another approach to handling unwanted messages is the use of whitelists.
+Whitelists as used in email most often simply bypass other measures when the
+sender identifies themselves as an entity on the whitelist. Whitelists in email
+are almost always a result of missclassification of messages as spam. While
+this may have applicability on the Actor level, we believe that the use of
+server whitelists in ActivityPub should be limited.
+
+Whitelists have been proposed on the ActivityPub Fediverse as a means of
+ensuring that mutual agreements between nodes are enforced. This approach is
+akin to an email provider that only explicitly allows messages from large well
+known organizations, for example by Google or Hotmail, and does not allow them
+from anyone else, including Universities or Non-Profits.
+
+Such whitelists are difficult to curate and more importantly, break the spirit
+of communication that as at the heart of the protocol.
+
+
+<a id="org1920bd4"></a>
+
+## Message Flagging/Sorting
+
+A simple approach to the issue of unwanted messages is to mark suspicious
+messages as such and place them outside of the normal message retrieval- either
+in a separate Inbox (eg a Spam Folder) or on another system altogether in
+"Quarantine". These same principles could be applied to ActivityPub by
+extending a single Inbox to multiple incoming Collections, each containing
+some subset of messages based on multiple analysis.
+
+Such collections could be presented to the end user in a number of ways, using
+the analogy of Tagging or directly as separate collections. We believe that
+separating out the collections has a secondary benefit of allowing the
+individual user to be prepared for either irrelevant or offensive content. For
+example, an Inbox collection labeled "Warning" may allow for sufficient
+emotional distance from the content such that even if a message is offensive
+that it could be handled more easily, or possibly allowing those messages to be
+screened further.
+
+
+<a id="orgdd78757"></a>
+
+## Postage
+
+All techniques used to identify and either block or sort unwanted messages
+exist because there are costs in handling such messages. These costs are
+bandwidth, electricity and storage, but also our valuable time and mental
+health. Rather than create techniques that place even greater cost on the
+receiver, it is possible to assign a cost value of sending messages to the
+sender.
+
+By requiring that the sender pay a cost, we shift the decision of whether or
+not a message is worth sending to the sender. rather than the recipient. As is
+shown by physical "Junk Mail", this does not necessarily eliminate all unwanted
+messages, but it does reduce incentive. The fee of sending messages could be
+paid in any number of ways, from systems such as with Hashcash<sup><a id="fnr.19" class="footref" href="#fn.19">19</a></sup>, paid
+with digital currency, or part of another system, such as requiring a sender to
+perform computational or storage tasks on behalf of the sender.
+
+Requiring the message sender to expend resources in terms of either work or
+currency has a number of benefits in reducing the incentive to send unwanted
+messages, we would encourage that implementers of this idea be focused on
+"fees" that that directly benefit the receiver. While proof of work systems
+like Hashcash are easy to implement, without adding a direct benefit to the
+receiver, they require the sender to expend resources. If extrapolated to a
+large scale, this could have a negative environmental impact due to wasted
+computing resources. It should also be noted that due to currency and cost of
+living differences, any form of fee whether paid directly or indirectly, will
+have a correspondingly different financial impact with greater proportional
+cost born by those in poorer countries.
+
+Because of these issues and the spirit of free communication, we would
+encourage any implementation of this technique to be used sparingly and only on
+the first message of a new sender, rather than on all messages.
+
+
+<a id="org8fee336"></a>
+
+## Bounce Messages
+
+The ActivityPub specification does not address a situation in which messages
+are rejected. While not strictly necessary, providing bounce messages does
+allow for well meaning server administrators to have an understanding of why
+their users' messages are not being delivered. We recommend an extension of the
+HTTP status codes to include a new "Not Accepted" status code representing the
+receipt of a request that is properly formatted but not accepted by the server
+by a reason not covered by one of the other methods. A textual or JSON
+representation of the full error message could then be provided to the HTTP
+client, allowing an ActivityPub server administrator the opportunity to see why
+messages are failing and take appropriate action.
+
+
+<a id="org6d9b938"></a>
+
+## Promises
+
+Because many of the techniques discussed in this proposal are expensive to
+perform, we suggest that in some cases a server may wish to handle the
+processing of the message asynchronously and return a Promise representing the
+status of message delivery which could then be queried at a later time to
+determine if the message was delivered successfully or rejected.
+
+These Promise statuses could use the same error codes as discussed in [3.13](#org8fee336) but not be required to keep the HTTP connection open during the
+determination of message suitability.
+
+
+<a id="org559f6a7"></a>
+
+# Combining Techniques
+
+As emphasized previously, the suggestions made in this proposal are meant to be
+used in conjunction with one another for maximum efficacy. For example,
+MultiBox used in conjunction with Object Capabilities Inboxes allows for
+per-Actor filtering to be performed more easily. OCAP Inboxes may also be
+granted which allow a sender to bypass other filters, acting effectively as an
+Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
+explored ACL vs OCAP inReplyTo functionality in [3.8](#orga9aeacc), and
+either of these techniques could be combined with content analysis.
+
+
+<a id="org0f0532f"></a>
+
+# A Note for ActivityPub Node Operators
+
+During the research for this paper, the author asked ActivityPub node operators
+what their experiences were with spammers and we received information that
+spammers were signing up for accounts on nodes. This presents a challenge to
+all parties involved.
+
+Many of the techniques in this document have been optimized for a scenario in
+which a spammer is operating their own servers. Understanding that spammers are
+attempting to use existing nodes makes the situation for those node operators
+more challenging as blocks may apply to an entire node. Therefore it becomes
+imperative for those who run nodes on the Fediverse to do their best not only
+to block incoming messages but to monitor their nodes for abusive behavior by
+their users.
+
+We have not addressed this issue in this paper but believe that the topic
+deserves further research.
+
+
+<a id="orgcb16a86"></a>
+
+# Conclusion
+
+In this paper, we have presented a number of techniques for keeping unwanted
+messages off an ActivityPub server. As emphasized previously, the suggestions
+made in this proposal are meant to be used in conjunction with one another for
+maximum efficacy. For example, MultiBox used in conjunction with Object
+Capabilities Inboxes allows for per-Actor filtering to be performed more
+easily. OCAP Inboxes may also be granted which allow a sender to bypass other
+filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
+may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
+[3.8](#orga9aeacc), and either of these techniques could be combined with
+content analysis.
+
+We believe that the problem of unwanted messages is addressable and we look
+forward to participating in building solutions.
+
+
+<a id="org00aa5bc"></a>
+
+# Endnotes
+
+
+# Footnotes
+
+<sup><a id="fn.1" href="#fnr.1">1</a></sup> <https://www.w3.org/TR/activitypub/>
+
+<sup><a id="fn.2" href="#fnr.2">2</a></sup> <https://the-federation.info/>
+
+<sup><a id="fn.3" href="#fnr.3">3</a></sup> <https://www.w3.org/TR/activitystreams-core/>
+
+<sup><a id="fn.4" href="#fnr.4">4</a></sup> <https://www.w3.org/wiki/SocialCG/ActivityPub/Authentication_Authorization#Signing_requests_using_HTTP_Signatures>
+
+<sup><a id="fn.5" href="#fnr.5">5</a></sup> <https://en.wikipedia.org/wiki/Robustness_principle>
+
+<sup><a id="fn.6" href="#fnr.6">6</a></sup> <https://www.rfc-editor.org/std/std13.txt>
+
+<sup><a id="fn.7" href="#fnr.7">7</a></sup> <https://tools.ietf.org/html/rfc5321>
+
+<sup><a id="fn.8" href="#fnr.8">8</a></sup> <https://www.greylisting.org/>
+
+<sup><a id="fn.9" href="#fnr.9">9</a></sup> <https://tools.ietf.org/html/rfc7231#section-6.5.9>
+
+<sup><a id="fn.10" href="#fnr.10">10</a></sup> <https://www.w3.org/TR/activitypub/#shared-inbox-delivery>
+
+<sup><a id="fn.11" href="#fnr.11">11</a></sup> <https://www.w3.org/TR/activitypub/#inbox-forwarding>
+
+<sup><a id="fn.12" href="#fnr.12">12</a></sup> <https://www.w3.org/TR/activitypub/#inbox>
+
+<sup><a id="fn.13" href="#fnr.13">13</a></sup> <https://www.w3.org/TR/activitypub/#client-to-server-interactions>
+
+<sup><a id="fn.14" href="#fnr.14">14</a></sup> <http://www.openspf.org/>
+
+<sup><a id="fn.15" href="#fnr.15">15</a></sup> <http://dkim.org/>
+
+<sup><a id="fn.16" href="#fnr.16">16</a></sup> <https://github.com/cwebber/rebooting-the-web-of-trust-spring2018/blob/petnames/topics-and-advance-readings/petnames.md>
+
+<sup><a id="fn.17" href="#fnr.17">17</a></sup> <http://www.paulgraham.com/spam.html>
+
+<sup><a id="fn.18" href="#fnr.18">18</a></sup> <https://federated.withgoogle.com/>
+
+<sup><a id="fn.19" href="#fnr.19">19</a></sup> <http://www.hashcash.org/>

--- a/topics-and-advance-readings/ap-unwanted-messages.md
+++ b/topics-and-advance-readings/ap-unwanted-messages.md
@@ -1,30 +1,30 @@
 
 # Table of Contents
 
-1.  [Introduction](#org0cb1b2e)
-2.  [ActivityPub Overview](#orgef57722)
-3.  [Proposed Suggestions](#org41786bf)
-    1.  [Enhanced Privacy of Followers/Following Collection](#org6c32426)
-    2.  [Strict Protocol Adherence](#orgcf764cd)
-    3.  [Object-Capabilities Based Inboxes](#org86f27df)
-    4.  [MultiBox](#orgddd1c45)
-    5.  [Multiple Inboxes/Message Sorting](#org7ca275c)
-    6.  [Sender Identification and Pet Names](#org63d8acf)
-    7.  [Blacklists](#orgaddb0f2)
-    8.  [Closing the Relay Hole](#orgcc3a6dc)
-    9.  [Content Based Filtering](#orge8cb386)
-    10. [Whitelists](#orged71066)
-    11. [Message Flagging/Sorting](#orgda2286c)
-    12. [Postage](#org4aa6313)
-    13. [Bounce Messages](#org87447fe)
-    14. [Promises](#orgda719ec)
-4.  [Combining Techniques](#orgd688634)
-5.  [A Note for ActivityPub Node Operators](#org9e2ea82)
-6.  [Conclusion](#orgad81b64)
+1.  [Introduction](#orgb37920a)
+2.  [ActivityPub Overview](#orgfd24d8f)
+3.  [Proposed Suggestions](#orgf91487c)
+    1.  [Enhanced Privacy of Followers/Following Collection](#org4abecc9)
+    2.  [Strict Protocol Adherence](#org88b5f83)
+    3.  [Object-Capabilities Based Inboxes](#org66711aa)
+    4.  [MultiBox](#orgb17e731)
+    5.  [Multiple Inboxes/Message Sorting](#org2d51b70)
+    6.  [Sender Identification and Pet Names](#org1b1516b)
+    7.  [Blacklists](#orgeb0ab28)
+    8.  [Closing the Relay Hole](#orge8883d9)
+    9.  [Content Based Filtering](#org20d581a)
+    10. [Whitelists](#org232eafd)
+    11. [Message Flagging/Sorting](#org9ae0f29)
+    12. [Postage](#org3f453e7)
+    13. [Bounce Messages](#org80ac7b7)
+    14. [Promises](#orgdb20ba4)
+4.  [Combining Techniques](#orgbcae480)
+5.  [A Note for ActivityPub Node Operators](#org872e81a)
+6.  [Conclusion](#org09ba1e0)
 
 
 
-<a id="org0cb1b2e"></a>
+<a id="orgb37920a"></a>
 
 # Introduction
 
@@ -59,7 +59,7 @@ multiple domains of messages, regardless of content or whether the messages are
 meant for a public or private audience.
 
 
-<a id="orgef57722"></a>
+<a id="orgfd24d8f"></a>
 
 # ActivityPub Overview
 
@@ -93,12 +93,12 @@ Actor Object. Requests made on behalf of that actor are then signed using the
 Actor's private key and may be verified against its public key.
 
 
-<a id="org41786bf"></a>
+<a id="orgf91487c"></a>
 
 # Proposed Suggestions
 
 
-<a id="org6c32426"></a>
+<a id="org4abecc9"></a>
 
 ## Enhanced Privacy of Followers/Following Collection
 
@@ -112,7 +112,7 @@ be disclosed to a third party or only be disclosed insofar as it related to the
 actor making the request.
 
 
-<a id="orgcf764cd"></a>
+<a id="org88b5f83"></a>
 
 ## Strict Protocol Adherence
 
@@ -144,7 +144,7 @@ Nonetheless, we mention this method because it has been so effective in email,
 and thus may be something to evaluate again in the future.
 
 
-<a id="org86f27df"></a>
+<a id="org66711aa"></a>
 
 ## Object-Capabilities Based Inboxes
 
@@ -172,7 +172,7 @@ This act of the sender handing out capabilities may be done in a number of
      "type": "Inbox",
      "to": ["https://chatty.example/ben/"],
      "attributedTo": "https://social.example/alyssa/",
-     "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
+     "alternativeInbox:: ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
 
 In our example, we show multiple inboxes being delivered. As part of the Object
 Capabilities model, these capabilities are transferable, which would allow one
@@ -193,7 +193,7 @@ endpoint as discussed previously. In such cases, a server would need to
 retrieve a new Inbox for an Actor as needed.
 
 
-<a id="orgddd1c45"></a>
+<a id="orgb17e731"></a>
 
 ## MultiBox
 
@@ -217,7 +217,7 @@ separated values<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup>.
 This has two advantages over Shared Inbox. Used on its own, it eliminates the
 vulnerability mentioned previously whereby recipients to a message do not need
 to be listed. If this proposal is adopted alongside the Object-Capabilities
-Based Inbox proposal ([3.3](#org86f27df)), the
+Based Inbox proposal ([3.3](#org66711aa)), the
 advantages multiply as we also gain the ability to appropriately filter
 incoming messages according to the criteria set out by the specific Inboxes, as
 well as letting us know the origin of each Inbox.
@@ -236,7 +236,7 @@ This would limit the number of per message recipients, though this limitation
  `MultiBox` object encapsulating the `Audience` field and the ~Activity.
 
 
-<a id="org7ca275c"></a>
+<a id="org2d51b70"></a>
 
 ## Multiple Inboxes/Message Sorting
 
@@ -255,12 +255,12 @@ protocol dictated in the ActivityPub standard.<sup><a id="fnr.13" class="footref
 
 A variety of techniques could be employed when sorting messages, including but
 not limited to the content based filtering techniques described in previous
-sections about filtering based on message content ([3.9](#orge8cb386)) or
-using OCAP Inboxes ([3.3](#org86f27df)) described in this
+sections about filtering based on message content ([3.9](#org20d581a)) or
+using OCAP Inboxes ([3.3](#org66711aa)) described in this
 whitepaper.
 
 
-<a id="org63d8acf"></a>
+<a id="org1b1516b"></a>
 
 ## Sender Identification and Pet Names
 
@@ -294,7 +294,7 @@ indicating that the communication is more likely to be useful.
 
 We recognize that this proposal may seem in contrast to the previous proposal
 of not disclosing connections to third parties as described in the section on
-improving privacy of Follower/Following Collections ([3.1](#org6c32426)), but the two can operate in tandem by making
+improving privacy of Follower/Following Collections ([3.1](#org4abecc9)), but the two can operate in tandem by making
 the ability to find a connection to your followers be a query, rather than a
 publicly available list. We could further enhance the security of this by
 adding additional restrictions onto the query functionality such as rate
@@ -306,7 +306,7 @@ believe that this would require further examination in order to be done in a
 way that protects a user's social graph.
 
 
-<a id="orgaddb0f2"></a>
+<a id="orgeb0ab28"></a>
 
 ## Blacklists
 
@@ -320,7 +320,7 @@ In ActivityPub an individual Actor or server administrator may choose to create
 a custom blocklist, but there is currently no standardized way to distribute or
 share blocklists. We propose that this be explored further, though cautiously
 by allowing Actors to query each other's either mute or block lists through a
-mechanism similar to the proposal described in the section on Pet Names ([3.6](#org63d8acf)).
+mechanism similar to the proposal described in the section on Pet Names ([3.6](#org1b1516b)).
 
 Actors who have agreed to peer with each other in regards to shared mute or
 block lists will be given an additional property in their actor object
@@ -347,7 +347,7 @@ miss out on messages that they might wish to recieve. The analogy of adblocking
 software is often used by those supporting this type of proposal, but in
 ad-blocking, it is possible to disable the software selectively when the
 functionality of a website does not work. With blocklists, unless they are
-paired with another proposal, such as the one about multiple inboxes ([3.5](#org7ca275c)), they may have the consequence of breaking federation.
+paired with another proposal, such as the one about multiple inboxes ([3.5](#org2d51b70)), they may have the consequence of breaking federation.
 
 Thirdly, the mechanism described precludes the ability to easily remove a
 block. If a block is removed, there is no mechanism that allows those who have
@@ -362,7 +362,7 @@ unwanted messages, unless we can address the concerns raised above, we cannot
 endorse their deployment.
 
 
-<a id="orgcc3a6dc"></a>
+<a id="orge8883d9"></a>
 
 ## Closing the Relay Hole
 
@@ -400,7 +400,7 @@ reply without moderation is given a new Inbox corresponding to this added
 capability.
 
 
-<a id="orge8cb386"></a>
+<a id="org20d581a"></a>
 
 ## Content Based Filtering
 
@@ -426,7 +426,7 @@ in creating training models that work well based on community standards of
 interest and behavior.
 
 
-<a id="orged71066"></a>
+<a id="org232eafd"></a>
 
 ## Whitelists
 
@@ -447,7 +447,7 @@ Such whitelists are difficult to curate and more importantly, break the spirit
 of communication that as at the heart of the protocol.
 
 
-<a id="orgda2286c"></a>
+<a id="org9ae0f29"></a>
 
 ## Message Flagging/Sorting
 
@@ -468,7 +468,7 @@ that it could be handled more easily, or possibly allowing those messages to be
 screened further.
 
 
-<a id="org4aa6313"></a>
+<a id="org3f453e7"></a>
 
 ## Postage
 
@@ -504,7 +504,7 @@ encourage any implementation of this technique to be used sparingly and only on
 the first message of a new sender, rather than on all messages.
 
 
-<a id="org87447fe"></a>
+<a id="org80ac7b7"></a>
 
 ## Bounce Messages
 
@@ -520,7 +520,7 @@ client, allowing an ActivityPub server administrator the opportunity to see why
 messages are failing and take appropriate action.
 
 
-<a id="orgda719ec"></a>
+<a id="orgdb20ba4"></a>
 
 ## Promises
 
@@ -531,11 +531,11 @@ status of message delivery which could then be queried at a later time to
 determine if the message was delivered successfully or rejected.
 
 These Promise statuses could use the same error codes as discussed in the
-section on Bounce Messages ([3.13](#org87447fe)) but not be required to keep the
+section on Bounce Messages ([3.13](#org80ac7b7)) but not be required to keep the
 HTTP connection open during the determination of message suitability.
 
 
-<a id="orgd688634"></a>
+<a id="orgbcae480"></a>
 
 # Combining Techniques
 
@@ -545,11 +545,11 @@ MultiBox used in conjunction with Object Capabilities Inboxes allows for
 per-Actor filtering to be performed more easily. OCAP Inboxes may also be
 granted which allow a sender to bypass other filters, acting effectively as an
 Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
-explored ACL vs OCAP inReplyTo functionality in [3.8](#orgcc3a6dc), and
+explored ACL vs OCAP inReplyTo functionality in [3.8](#orge8883d9), and
 either of these techniques could be combined with content analysis.
 
 
-<a id="org9e2ea82"></a>
+<a id="org872e81a"></a>
 
 # A Note for ActivityPub Node Operators
 
@@ -570,7 +570,7 @@ We have not addressed this issue in this paper but believe that the topic
 deserves further research.
 
 
-<a id="orgad81b64"></a>
+<a id="org09ba1e0"></a>
 
 # Conclusion
 
@@ -582,7 +582,7 @@ Capabilities Inboxes allows for per-Actor filtering to be performed more
 easily. OCAP Inboxes may also be granted which allow a sender to bypass other
 filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
 may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
-[3.8](#orgcc3a6dc), and either of these techniques could be combined with
+[3.8](#orge8883d9), and either of these techniques could be combined with
 content analysis.
 
 We believe that the problem of unwanted messages is addressable and we look

--- a/topics-and-advance-readings/ap-unwanted-messages.md
+++ b/topics-and-advance-readings/ap-unwanted-messages.md
@@ -1,30 +1,33 @@
 
 # Table of Contents
 
-1.  [Introduction](#orge0c4a68)
-2.  [ActivityPub Overview](#org11a2d9d)
-3.  [Proposed Suggestions](#orgfaea2da)
-    1.  [Enhanced Privacy of Followers/Following Collection](#org27d6e37)
-    2.  [Strict Protocol Adherence](#org76f1106)
-    3.  [Object-Capabilities Based Inboxes](#org925b8d8)
-    4.  [MultiBox](#org713a7a8)
-    5.  [Multiple Inboxes/Message Sorting](#org09e08ee)
-    6.  [Sender Identification and Pet Names](#orgb7845ee)
-    7.  [Blacklists](#org235c9de)
-    8.  [Closing the Relay Hole](#orge622c90)
-    9.  [Content Based Filtering](#orgea7a41f)
-    10. [Whitelists](#org5be70bc)
-    11. [Message Flagging/Sorting](#org1be106a)
-    12. [Postage](#orgfbb0670)
-    13. [Bounce Messages](#orgf071be6)
-    14. [Promises](#org30bcaa0)
-4.  [Combining Techniques](#org408aace)
-5.  [A Note for ActivityPub Node Operators](#orgc186969)
-6.  [Conclusion](#orgb3c34e7)
+1.  [Introduction](#orga7bd774)
+2.  [ActivityPub Overview](#orgb21f688)
+3.  [The Fediverse Today and Unwanted Messages](#org2158b95)
+4.  [Proposed Suggestions](#org0327ae3)
+    1.  [Mandatory Activity and Object Validation](#org6d76115)
+    2.  [HTTP Signature Validation](#org2aecaba)
+    3.  [Enhanced Privacy of Followers/Following Collection](#org68b0152)
+    4.  [Strict Protocol Adherence](#orga345a07)
+    5.  [Object-Capabilities Based Inboxes](#orgba8ad07)
+    6.  [MultiBox](#org7937fed)
+    7.  [Multiple Inboxes/Message Sorting](#org179021c)
+    8.  [Sender Identification and Pet Names](#org5dbdd7f)
+    9.  [Blacklists](#orgdc263ce)
+    10. [Closing the Relay Hole](#org50fef34)
+    11. [Content Based Filtering](#orga2680be)
+    12. [Whitelists](#orgdc8155b)
+    13. [Message Flagging/Sorting](#orgfbb0657)
+    14. [Postage](#org6988e08)
+    15. [Bounce Messages](#org3370488)
+    16. [Promises](#org0983769)
+5.  [Combining Techniques](#orge48a42e)
+6.  [A Note for ActivityPub Node Operators](#org9339e40)
+7.  [Conclusion](#orgde4153c)
 
 
 
-<a id="orge0c4a68"></a>
+<a id="orga7bd774"></a>
 
 # Introduction
 
@@ -59,7 +62,7 @@ multiple domains of messages, regardless of content or whether the messages are
 meant for a public or private audience.
 
 
-<a id="org11a2d9d"></a>
+<a id="orgb21f688"></a>
 
 # ActivityPub Overview
 
@@ -93,12 +96,43 @@ Actor Object. Requests made on behalf of that actor are then signed using the
 Actor's private key and may be verified against its public key.
 
 
-<a id="orgfaea2da"></a>
+<a id="org2158b95"></a>
+
+# The Fediverse Today and Unwanted Messages
+
+
+<a id="org0327ae3"></a>
 
 # Proposed Suggestions
 
 
-<a id="org27d6e37"></a>
+<a id="org6d76115"></a>
+
+## Mandatory Activity and Object Validation
+
+The ActivityPub standard itself provides only basic guidelines into validation
+of messages but does recommend verifying external objects and activities as a
+base minimum mechanism against spoofed messages.<sup><a id="fnr.5" class="footref" href="#fn.5">5</a></sup> Based on anecdotes from
+operators on the Fediverse, this technique alone has been effective in either
+the case of spoofed messages or the case where an account has been created,
+sends messages and is then shut down for abuse. In either case, we recommend
+that all ActivityPub implementations validate Activities and Objects in order
+to eliminate this unwanted message vector.
+
+
+<a id="org2aecaba"></a>
+
+## HTTP Signature Validation
+
+The HTTP Signatures extension, while not officially part of the ActivityPub
+standard has been acting as a de-facto standard for authentication on the
+Fediverse. We recommend that unless and until another authentication mechanism
+offering the same benefits as HTTP Signatures becomes available and generally
+adopted that HTTP Signatures be implemented in ActivityPub software and HTTP
+Signature validation of messages should then be assumed.
+
+
+<a id="org68b0152"></a>
 
 ## Enhanced Privacy of Followers/Following Collection
 
@@ -112,18 +146,18 @@ be disclosed to a third party or only be disclosed insofar as it related to the
 actor making the request.
 
 
-<a id="org76f1106"></a>
+<a id="orga345a07"></a>
 
 ## Strict Protocol Adherence
 
 Postel's law states that a protocol implementer should be strict in what they
-send and liberal in what they accept.<sup><a id="fnr.5" class="footref" href="#fn.5">5</a></sup>. At the same time, email operators
+send and liberal in what they accept.<sup><a id="fnr.6" class="footref" href="#fn.6">6</a></sup>. At the same time, email operators
 have found that many spammers' servers do not adhere strictly to the SMTP
 protocol. As an example, many mail servers lack a Forward-Confirmed Reverse DNS
-record<sup><a id="fnr.6" class="footref" href="#fn.6">6</a></sup> or send a HELO/EHLO that is not a fully qualified domain name or
-does not match the sender<sup><a id="fnr.7" class="footref" href="#fn.7">7</a></sup>. Many such servers also lack the ability to
+record<sup><a id="fnr.7" class="footref" href="#fn.7">7</a></sup> or send a HELO/EHLO that is not a fully qualified domain name or
+does not match the sender<sup><a id="fnr.8" class="footref" href="#fn.8">8</a></sup>. Many such servers also lack the ability to
 retry messages in the case of temporary failure, a situation that is utilized
-in greylisting<sup><a id="fnr.8" class="footref" href="#fn.8">8</a></sup>. Because of this pattern of non-compliance, one common
+in greylisting<sup><a id="fnr.9" class="footref" href="#fn.9">9</a></sup>. Because of this pattern of non-compliance, one common
 technique to reduce spam in email is to find the areas of the protocol that are
 commonly skipped by spammers and either block access or restrict access based
 on non-compliance.
@@ -144,7 +178,7 @@ Nonetheless, we mention this method because it has been so effective in email,
 and thus may be something to evaluate again in the future.
 
 
-<a id="org925b8d8"></a>
+<a id="orgba8ad07"></a>
 
 ## Object-Capabilities Based Inboxes
 
@@ -182,7 +216,7 @@ where the recipient is a trusted party.
 If one Inbox becomes abused, we are able to trace back to exactly when and for
 who the Inbox was generated. We are also able to revoke the Inbox, stopping any
 future requests to it. An HTTP request sent to an expired Inbox should ideally
-result in an HTTP 410 (Gone)<sup><a id="fnr.9" class="footref" href="#fn.9">9</a></sup>, alerting the sending to the unavailability
+result in an HTTP 410 (Gone)<sup><a id="fnr.10" class="footref" href="#fn.10">10</a></sup>, alerting the sending to the unavailability
 of the inbox and prompting it to request a new one if it wishes to resume
 communication.
 
@@ -192,11 +226,11 @@ implementation does not understand the new Inbox being offered, they would
 continue to go through a "Default Inbox" route.
 
 
-<a id="org713a7a8"></a>
+<a id="org7937fed"></a>
 
 ## MultiBox
 
-`Shared Inbox`<sup><a id="fnr.10" class="footref" href="#fn.10">10</a></sup> provides the ability for server to server communication
+`Shared Inbox`<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup> provides the ability for server to server communication
 traffic to be reduced from R requests, where R is the number of recipients, to
 a single HTTP request. This is a desirable property as it reduces the amount of
 HTTP round trips for both the sender and receiver. Unfortunately the design of
@@ -211,12 +245,12 @@ Actors. Unlike Shared Inbox, in a MultiBox request, each recipient is
 explicitly listed *by Inbox*, requiring both the knowledge of the Actor and a
 corresponding Inbox for that actor. This information is transmitted through the
 use of an HTTP header `Audience` where each Inbox is listed using comma
-separated values<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup>.
+separated values<sup><a id="fnr.12" class="footref" href="#fn.12">12</a></sup>.
 
 This has two advantages over Shared Inbox. Used on its own, it eliminates the
 vulnerability mentioned previously whereby recipients to a message do not need
 to be listed. If this proposal is adopted alongside the Object-Capabilities
-Based Inbox proposal ([3.3](#org925b8d8)), the
+Based Inbox proposal ([4.5](#orgba8ad07)), the
 advantages multiply as we also gain the ability to appropriately filter
 incoming messages according to the criteria set out by the specific Inboxes, as
 well as letting us know the origin of each Inbox.
@@ -235,11 +269,11 @@ This would limit the number of per message recipients, though this limitation
  `MultiBox` object encapsulating the `Audience` field and the ~Activity.
 
 
-<a id="org09e08ee"></a>
+<a id="org179021c"></a>
 
 ## Multiple Inboxes/Message Sorting
 
-The ActivityPub protocol specifies an `Inbox` collection<sup><a id="fnr.12" class="footref" href="#fn.12">12</a></sup> to store
+The ActivityPub protocol specifies an `Inbox` collection<sup><a id="fnr.13" class="footref" href="#fn.13">13</a></sup> to store
 incoming messages for the Actor. This functions similarly to the common Email
 Inbox where by default, messages arrive. As thinking regarding email has
 evolved, automatic message sorting has been employed using either actual
@@ -250,16 +284,16 @@ corresponding to sorting rules.
 This extension to the ActivityPub protocol would not have to be visible to any
 external entities (ie not accessible through the Server-To-Server
 communication) but only through the Client to Server (C2S) communication
-protocol dictated in the ActivityPub standard.<sup><a id="fnr.13" class="footref" href="#fn.13">13</a></sup>
+protocol dictated in the ActivityPub standard.<sup><a id="fnr.14" class="footref" href="#fn.14">14</a></sup>
 
 A variety of techniques could be employed when sorting messages, including but
 not limited to the content based filtering techniques described in previous
-sections about filtering based on message content ([3.9](#orgea7a41f)) or
-using OCAP Inboxes ([3.3](#org925b8d8)) described in this
+sections about filtering based on message content ([4.11](#orga2680be)) or
+using OCAP Inboxes ([4.5](#orgba8ad07)) described in this
 whitepaper.
 
 
-<a id="orgb7845ee"></a>
+<a id="org5dbdd7f"></a>
 
 ## Sender Identification and Pet Names
 
@@ -271,7 +305,7 @@ literature as either *Joe Jobbing* or *Phishing*.
 
 In Email, verification is largely achieved by verifying that the email server
 is trusted for the domain which it purports to deliver email, often through an
-out of band technique, often involving DNS, such as SPF<sup><a id="fnr.14" class="footref" href="#fn.14">14</a></sup> or DKIM<sup><a id="fnr.15" class="footref" href="#fn.15">15</a></sup>.
+out of band technique, often involving DNS, such as SPF<sup><a id="fnr.15" class="footref" href="#fn.15">15</a></sup> or DKIM<sup><a id="fnr.16" class="footref" href="#fn.16">16</a></sup>.
 
 In ActivityPub, sender identification is performed at the Actor level using the
 HTTP Signatures.<sup><a id="fnr.4.100" class="footref" href="#fn.4">4</a></sup> With this extension, each Actor has a public and private
@@ -284,7 +318,7 @@ by the receiving server for authenticity.
 
 We propose to extend this validation with a second layer of identity validation
 through the use of Pet Names. The Pet Names proposal presented in Rebooting Web
-of Trust 2018<sup><a id="fnr.16" class="footref" href="#fn.16">16</a></sup> has a secondary property of being able to be used as
+of Trust 2018<sup><a id="fnr.17" class="footref" href="#fn.17">17</a></sup> has a secondary property of being able to be used as
 simplified trust mechanism. When a sender would like to make contact with a
 receiver, the receiver checks its neighbors (Followers or Following) for a pet
 name for this sender. If a neighbor has decided to give this sender a Pet Name,
@@ -293,7 +327,7 @@ indicating that the communication is more likely to be useful.
 
 We recognize that this proposal may seem in contrast to the previous proposal
 of not disclosing connections to third parties as described in the section on
-improving privacy of Follower/Following Collections ([3.1](#org27d6e37)), but the two can operate in tandem by making
+improving privacy of Follower/Following Collections ([4.3](#org68b0152)), but the two can operate in tandem by making
 the ability to find a connection to your followers be a query, rather than a
 publicly available list. We could further enhance the security of this by
 adding additional restrictions onto the query functionality such as rate
@@ -305,7 +339,7 @@ believe that this would require further examination in order to be done in a
 way that protects a user's social graph.
 
 
-<a id="org235c9de"></a>
+<a id="orgdc263ce"></a>
 
 ## Blacklists
 
@@ -319,7 +353,7 @@ In ActivityPub an individual Actor or server administrator may choose to create
 a custom blocklist, but there is currently no standardized way to distribute or
 share blocklists. We propose that this be explored further, though cautiously
 by allowing Actors to query each other's either mute or block lists through a
-mechanism similar to the proposal described in the section on Pet Names ([3.6](#orgb7845ee)).
+mechanism similar to the proposal described in the section on Pet Names ([4.8](#org5dbdd7f)).
 
 Actors who have agreed to peer with each other in regards to shared mute or
 block lists will be given an additional property in their actor object
@@ -346,7 +380,7 @@ miss out on messages that they might wish to recieve. The analogy of adblocking
 software is often used by those supporting this type of proposal, but in
 ad-blocking, it is possible to disable the software selectively when the
 functionality of a website does not work. With blocklists, unless they are
-paired with another proposal, such as the one about multiple inboxes ([3.5](#org09e08ee)), they may have the consequence of breaking federation.
+paired with another proposal, such as the one about multiple inboxes ([4.7](#org179021c)), they may have the consequence of breaking federation.
 
 Thirdly, the mechanism described precludes the ability to easily remove a
 block. If a block is removed, there is no mechanism that allows those who have
@@ -361,7 +395,7 @@ unwanted messages, unless we can address the concerns raised above, we cannot
 endorse their deployment.
 
 
-<a id="orge622c90"></a>
+<a id="org50fef34"></a>
 
 ## Closing the Relay Hole
 
@@ -374,7 +408,7 @@ messages on their behalf. Because of this, many mail servers block "Open Mail
 Relays".
 
 In ActivityPub, message relaying is performed in accordance with Section 7.1.2
-of the ActivityPub specification<sup><a id="fnr.11.100" class="footref" href="#fn.11">11</a></sup> in order to mitigate the "Ghost Replies"
+of the ActivityPub specification<sup><a id="fnr.12.100" class="footref" href="#fn.12">12</a></sup> in order to mitigate the "Ghost Replies"
 problem, where a rely to a message is not seen by everyone watching that thread
 because the replier does not send the message to everyone that the original
 sender did. Unfortunately this also opens up replies as a vector of abuse in
@@ -399,7 +433,7 @@ reply without moderation is given a new Inbox corresponding to this added
 capability.
 
 
-<a id="orgea7a41f"></a>
+<a id="orga2680be"></a>
 
 ## Content Based Filtering
 
@@ -411,11 +445,11 @@ looking for other signifiers such as messages that appear to be phishing
 attempts.
 
 Content based filtering can take many forms, from simple rule based filters, to
-Baysean text analysis<sup><a id="fnr.17" class="footref" href="#fn.17">17</a></sup>, sentiment analysis or even more complex image
+Baysean text analysis<sup><a id="fnr.18" class="footref" href="#fn.18">18</a></sup>, sentiment analysis or even more complex image
 classification.
 
 An exciting area of further exploration may be the use of Federated
-Learning<sup><a id="fnr.18" class="footref" href="#fn.18">18</a></sup>, whereby training can be performed in a way that allows
+Learning<sup><a id="fnr.19" class="footref" href="#fn.19">19</a></sup>, whereby training can be performed in a way that allows
 individual data to be kept private but the results may be shared and built
 upon.
 
@@ -425,7 +459,7 @@ in creating training models that work well based on community standards of
 interest and behavior.
 
 
-<a id="org5be70bc"></a>
+<a id="orgdc8155b"></a>
 
 ## Whitelists
 
@@ -446,7 +480,7 @@ Such whitelists are difficult to curate and more importantly, break the spirit
 of communication that as at the heart of the protocol.
 
 
-<a id="org1be106a"></a>
+<a id="orgfbb0657"></a>
 
 ## Message Flagging/Sorting
 
@@ -467,7 +501,7 @@ that it could be handled more easily, or possibly allowing those messages to be
 screened further.
 
 
-<a id="orgfbb0670"></a>
+<a id="org6988e08"></a>
 
 ## Postage
 
@@ -482,7 +516,7 @@ By requiring that the sender pay a cost, we shift the decision of whether or
 not a message is worth sending to the sender. rather than the recipient. As is
 shown by physical "Junk Mail", this does not necessarily eliminate all unwanted
 messages, but it does reduce incentive. The fee of sending messages could be
-paid in any number of ways, from systems such as with Hashcash<sup><a id="fnr.19" class="footref" href="#fn.19">19</a></sup>, paid
+paid in any number of ways, from systems such as with Hashcash<sup><a id="fnr.20" class="footref" href="#fn.20">20</a></sup>, paid
 with digital currency, or part of another system, such as requiring a sender to
 perform computational or storage tasks on behalf of the sender.
 
@@ -508,7 +542,7 @@ encourage any implementation of this technique to be used sparingly and only on
 the first message of a new sender, rather than on all messages.
 
 
-<a id="orgf071be6"></a>
+<a id="org3370488"></a>
 
 ## Bounce Messages
 
@@ -524,7 +558,7 @@ client, allowing an ActivityPub server administrator the opportunity to see why
 messages are failing and take appropriate action.
 
 
-<a id="org30bcaa0"></a>
+<a id="org0983769"></a>
 
 ## Promises
 
@@ -535,11 +569,11 @@ status of message delivery which could then be queried at a later time to
 determine if the message was delivered successfully or rejected.
 
 These Promise statuses could use the same error codes as discussed in the
-section on Bounce Messages ([3.13](#orgf071be6)) but not be required to keep the
+section on Bounce Messages ([4.15](#org3370488)) but not be required to keep the
 HTTP connection open during the determination of message suitability.
 
 
-<a id="org408aace"></a>
+<a id="orge48a42e"></a>
 
 # Combining Techniques
 
@@ -549,11 +583,11 @@ MultiBox used in conjunction with Object Capabilities Inboxes allows for
 per-Actor filtering to be performed more easily. OCAP Inboxes may also be
 granted which allow a sender to bypass other filters, acting effectively as an
 Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
-explored ACL vs OCAP inReplyTo functionality in [3.8](#orge622c90), and
+explored ACL vs OCAP inReplyTo functionality in [4.10](#org50fef34), and
 either of these techniques could be combined with content analysis.
 
 
-<a id="orgc186969"></a>
+<a id="org9339e40"></a>
 
 # A Note for ActivityPub Node Operators
 
@@ -574,7 +608,7 @@ We have not addressed this issue in this paper but believe that the topic
 deserves further research.
 
 
-<a id="orgb3c34e7"></a>
+<a id="orgde4153c"></a>
 
 # Conclusion
 
@@ -586,7 +620,7 @@ Capabilities Inboxes allows for per-Actor filtering to be performed more
 easily. OCAP Inboxes may also be granted which allow a sender to bypass other
 filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
 may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
-[3.8](#orge622c90), and either of these techniques could be combined with
+[4.10](#org50fef34), and either of these techniques could be combined with
 content analysis.
 
 We believe that the problem of unwanted messages is addressable and we look
@@ -603,32 +637,34 @@ forward to participating in building solutions.
 
 <sup><a id="fn.4" href="#fnr.4">4</a></sup> <https://www.w3.org/wiki/SocialCG/ActivityPub/Authentication_Authorization#Signing_requests_using_HTTP_Signatures>
 
-<sup><a id="fn.5" href="#fnr.5">5</a></sup> <https://en.wikipedia.org/wiki/Robustness_principle>
+<sup><a id="fn.5" href="#fnr.5">5</a></sup> <https://www.w3.org/TR/activitypub/#obj>
 
-<sup><a id="fn.6" href="#fnr.6">6</a></sup> <https://www.rfc-editor.org/std/std13.txt>
+<sup><a id="fn.6" href="#fnr.6">6</a></sup> <https://en.wikipedia.org/wiki/Robustness_principle>
 
-<sup><a id="fn.7" href="#fnr.7">7</a></sup> <https://tools.ietf.org/html/rfc5321>
+<sup><a id="fn.7" href="#fnr.7">7</a></sup> <https://www.rfc-editor.org/std/std13.txt>
 
-<sup><a id="fn.8" href="#fnr.8">8</a></sup> <https://www.greylisting.org/>
+<sup><a id="fn.8" href="#fnr.8">8</a></sup> <https://tools.ietf.org/html/rfc5321>
 
-<sup><a id="fn.9" href="#fnr.9">9</a></sup> <https://tools.ietf.org/html/rfc7231#section-6.5.9>
+<sup><a id="fn.9" href="#fnr.9">9</a></sup> <https://www.greylisting.org/>
 
-<sup><a id="fn.10" href="#fnr.10">10</a></sup> <https://www.w3.org/TR/activitypub/#shared-inbox-delivery>
+<sup><a id="fn.10" href="#fnr.10">10</a></sup> <https://tools.ietf.org/html/rfc7231#section-6.5.9>
 
-<sup><a id="fn.11" href="#fnr.11">11</a></sup> <https://www.w3.org/TR/activitypub/#inbox-forwarding>
+<sup><a id="fn.11" href="#fnr.11">11</a></sup> <https://www.w3.org/TR/activitypub/#shared-inbox-delivery>
 
-<sup><a id="fn.12" href="#fnr.12">12</a></sup> <https://www.w3.org/TR/activitypub/#inbox>
+<sup><a id="fn.12" href="#fnr.12">12</a></sup> <https://www.w3.org/TR/activitypub/#inbox-forwarding>
 
-<sup><a id="fn.13" href="#fnr.13">13</a></sup> <https://www.w3.org/TR/activitypub/#client-to-server-interactions>
+<sup><a id="fn.13" href="#fnr.13">13</a></sup> <https://www.w3.org/TR/activitypub/#inbox>
 
-<sup><a id="fn.14" href="#fnr.14">14</a></sup> <http://www.openspf.org/>
+<sup><a id="fn.14" href="#fnr.14">14</a></sup> <https://www.w3.org/TR/activitypub/#client-to-server-interactions>
 
-<sup><a id="fn.15" href="#fnr.15">15</a></sup> <http://dkim.org/>
+<sup><a id="fn.15" href="#fnr.15">15</a></sup> <http://www.openspf.org/>
 
-<sup><a id="fn.16" href="#fnr.16">16</a></sup> <https://github.com/cwebber/rebooting-the-web-of-trust-spring2018/blob/petnames/topics-and-advance-readings/petnames.md>
+<sup><a id="fn.16" href="#fnr.16">16</a></sup> <http://dkim.org/>
 
-<sup><a id="fn.17" href="#fnr.17">17</a></sup> <http://www.paulgraham.com/spam.html>
+<sup><a id="fn.17" href="#fnr.17">17</a></sup> <https://github.com/cwebber/rebooting-the-web-of-trust-spring2018/blob/petnames/topics-and-advance-readings/petnames.md>
 
-<sup><a id="fn.18" href="#fnr.18">18</a></sup> <https://federated.withgoogle.com/>
+<sup><a id="fn.18" href="#fnr.18">18</a></sup> <http://www.paulgraham.com/spam.html>
 
-<sup><a id="fn.19" href="#fnr.19">19</a></sup> <http://www.hashcash.org/>
+<sup><a id="fn.19" href="#fnr.19">19</a></sup> <https://federated.withgoogle.com/>
+
+<sup><a id="fn.20" href="#fnr.20">20</a></sup> <http://www.hashcash.org/>

--- a/topics-and-advance-readings/ap-unwanted-messages.md
+++ b/topics-and-advance-readings/ap-unwanted-messages.md
@@ -1,30 +1,30 @@
 
 # Table of Contents
 
-1.  [Introduction](#orgb37920a)
-2.  [ActivityPub Overview](#orgfd24d8f)
-3.  [Proposed Suggestions](#orgf91487c)
-    1.  [Enhanced Privacy of Followers/Following Collection](#org4abecc9)
-    2.  [Strict Protocol Adherence](#org88b5f83)
-    3.  [Object-Capabilities Based Inboxes](#org66711aa)
-    4.  [MultiBox](#orgb17e731)
-    5.  [Multiple Inboxes/Message Sorting](#org2d51b70)
-    6.  [Sender Identification and Pet Names](#org1b1516b)
-    7.  [Blacklists](#orgeb0ab28)
-    8.  [Closing the Relay Hole](#orge8883d9)
-    9.  [Content Based Filtering](#org20d581a)
-    10. [Whitelists](#org232eafd)
-    11. [Message Flagging/Sorting](#org9ae0f29)
-    12. [Postage](#org3f453e7)
-    13. [Bounce Messages](#org80ac7b7)
-    14. [Promises](#orgdb20ba4)
-4.  [Combining Techniques](#orgbcae480)
-5.  [A Note for ActivityPub Node Operators](#org872e81a)
-6.  [Conclusion](#org09ba1e0)
+1.  [Introduction](#orge0c4a68)
+2.  [ActivityPub Overview](#org11a2d9d)
+3.  [Proposed Suggestions](#orgfaea2da)
+    1.  [Enhanced Privacy of Followers/Following Collection](#org27d6e37)
+    2.  [Strict Protocol Adherence](#org76f1106)
+    3.  [Object-Capabilities Based Inboxes](#org925b8d8)
+    4.  [MultiBox](#org713a7a8)
+    5.  [Multiple Inboxes/Message Sorting](#org09e08ee)
+    6.  [Sender Identification and Pet Names](#orgb7845ee)
+    7.  [Blacklists](#org235c9de)
+    8.  [Closing the Relay Hole](#orge622c90)
+    9.  [Content Based Filtering](#orgea7a41f)
+    10. [Whitelists](#org5be70bc)
+    11. [Message Flagging/Sorting](#org1be106a)
+    12. [Postage](#orgfbb0670)
+    13. [Bounce Messages](#orgf071be6)
+    14. [Promises](#org30bcaa0)
+4.  [Combining Techniques](#org408aace)
+5.  [A Note for ActivityPub Node Operators](#orgc186969)
+6.  [Conclusion](#orgb3c34e7)
 
 
 
-<a id="orgb37920a"></a>
+<a id="orge0c4a68"></a>
 
 # Introduction
 
@@ -59,7 +59,7 @@ multiple domains of messages, regardless of content or whether the messages are
 meant for a public or private audience.
 
 
-<a id="orgfd24d8f"></a>
+<a id="org11a2d9d"></a>
 
 # ActivityPub Overview
 
@@ -93,12 +93,12 @@ Actor Object. Requests made on behalf of that actor are then signed using the
 Actor's private key and may be verified against its public key.
 
 
-<a id="orgf91487c"></a>
+<a id="orgfaea2da"></a>
 
 # Proposed Suggestions
 
 
-<a id="org4abecc9"></a>
+<a id="org27d6e37"></a>
 
 ## Enhanced Privacy of Followers/Following Collection
 
@@ -112,7 +112,7 @@ be disclosed to a third party or only be disclosed insofar as it related to the
 actor making the request.
 
 
-<a id="org88b5f83"></a>
+<a id="org76f1106"></a>
 
 ## Strict Protocol Adherence
 
@@ -144,7 +144,7 @@ Nonetheless, we mention this method because it has been so effective in email,
 and thus may be something to evaluate again in the future.
 
 
-<a id="org66711aa"></a>
+<a id="org925b8d8"></a>
 
 ## Object-Capabilities Based Inboxes
 
@@ -172,12 +172,12 @@ This act of the sender handing out capabilities may be done in a number of
      "type": "Inbox",
      "to": ["https://chatty.example/ben/"],
      "attributedTo": "https://social.example/alyssa/",
-     "alternativeInbox:: ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
+     "preferredInbox ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
 
-In our example, we show multiple inboxes being delivered. As part of the Object
+In our example, we show multiple inboxes being offered. As part of the Object
 Capabilities model, these capabilities are transferable, which would allow one
 actor to send an inbox capability to another actor, for example in a situation
-where the recipient is a trusted party. 
+where the recipient is a trusted party.
 
 If one Inbox becomes abused, we are able to trace back to exactly when and for
 who the Inbox was generated. We are also able to revoke the Inbox, stopping any
@@ -187,13 +187,12 @@ of the inbox and prompting it to request a new one if it wishes to resume
 communication.
 
 The OCAP Inbox model as described in this proposal would require little or no
-changes to existing deployed ActivityPub servers except where such servers are
-not prepared to accept a non-success (200) result when posting to an HTTP
-endpoint as discussed previously. In such cases, a server would need to
-retrieve a new Inbox for an Actor as needed.
+changes to existing deployed ActivityPub servers. In the case where an
+implementation does not understand the new Inbox being offered, they would
+continue to go through a "Default Inbox" route.
 
 
-<a id="orgb17e731"></a>
+<a id="org713a7a8"></a>
 
 ## MultiBox
 
@@ -217,7 +216,7 @@ separated values<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup>.
 This has two advantages over Shared Inbox. Used on its own, it eliminates the
 vulnerability mentioned previously whereby recipients to a message do not need
 to be listed. If this proposal is adopted alongside the Object-Capabilities
-Based Inbox proposal ([3.3](#org66711aa)), the
+Based Inbox proposal ([3.3](#org925b8d8)), the
 advantages multiply as we also gain the ability to appropriately filter
 incoming messages according to the criteria set out by the specific Inboxes, as
 well as letting us know the origin of each Inbox.
@@ -236,7 +235,7 @@ This would limit the number of per message recipients, though this limitation
  `MultiBox` object encapsulating the `Audience` field and the ~Activity.
 
 
-<a id="org2d51b70"></a>
+<a id="org09e08ee"></a>
 
 ## Multiple Inboxes/Message Sorting
 
@@ -255,12 +254,12 @@ protocol dictated in the ActivityPub standard.<sup><a id="fnr.13" class="footref
 
 A variety of techniques could be employed when sorting messages, including but
 not limited to the content based filtering techniques described in previous
-sections about filtering based on message content ([3.9](#org20d581a)) or
-using OCAP Inboxes ([3.3](#org66711aa)) described in this
+sections about filtering based on message content ([3.9](#orgea7a41f)) or
+using OCAP Inboxes ([3.3](#org925b8d8)) described in this
 whitepaper.
 
 
-<a id="org1b1516b"></a>
+<a id="orgb7845ee"></a>
 
 ## Sender Identification and Pet Names
 
@@ -294,7 +293,7 @@ indicating that the communication is more likely to be useful.
 
 We recognize that this proposal may seem in contrast to the previous proposal
 of not disclosing connections to third parties as described in the section on
-improving privacy of Follower/Following Collections ([3.1](#org4abecc9)), but the two can operate in tandem by making
+improving privacy of Follower/Following Collections ([3.1](#org27d6e37)), but the two can operate in tandem by making
 the ability to find a connection to your followers be a query, rather than a
 publicly available list. We could further enhance the security of this by
 adding additional restrictions onto the query functionality such as rate
@@ -306,7 +305,7 @@ believe that this would require further examination in order to be done in a
 way that protects a user's social graph.
 
 
-<a id="orgeb0ab28"></a>
+<a id="org235c9de"></a>
 
 ## Blacklists
 
@@ -320,7 +319,7 @@ In ActivityPub an individual Actor or server administrator may choose to create
 a custom blocklist, but there is currently no standardized way to distribute or
 share blocklists. We propose that this be explored further, though cautiously
 by allowing Actors to query each other's either mute or block lists through a
-mechanism similar to the proposal described in the section on Pet Names ([3.6](#org1b1516b)).
+mechanism similar to the proposal described in the section on Pet Names ([3.6](#orgb7845ee)).
 
 Actors who have agreed to peer with each other in regards to shared mute or
 block lists will be given an additional property in their actor object
@@ -347,7 +346,7 @@ miss out on messages that they might wish to recieve. The analogy of adblocking
 software is often used by those supporting this type of proposal, but in
 ad-blocking, it is possible to disable the software selectively when the
 functionality of a website does not work. With blocklists, unless they are
-paired with another proposal, such as the one about multiple inboxes ([3.5](#org2d51b70)), they may have the consequence of breaking federation.
+paired with another proposal, such as the one about multiple inboxes ([3.5](#org09e08ee)), they may have the consequence of breaking federation.
 
 Thirdly, the mechanism described precludes the ability to easily remove a
 block. If a block is removed, there is no mechanism that allows those who have
@@ -362,7 +361,7 @@ unwanted messages, unless we can address the concerns raised above, we cannot
 endorse their deployment.
 
 
-<a id="orge8883d9"></a>
+<a id="orge622c90"></a>
 
 ## Closing the Relay Hole
 
@@ -400,7 +399,7 @@ reply without moderation is given a new Inbox corresponding to this added
 capability.
 
 
-<a id="org20d581a"></a>
+<a id="orgea7a41f"></a>
 
 ## Content Based Filtering
 
@@ -426,7 +425,7 @@ in creating training models that work well based on community standards of
 interest and behavior.
 
 
-<a id="org232eafd"></a>
+<a id="org5be70bc"></a>
 
 ## Whitelists
 
@@ -447,7 +446,7 @@ Such whitelists are difficult to curate and more importantly, break the spirit
 of communication that as at the heart of the protocol.
 
 
-<a id="org9ae0f29"></a>
+<a id="org1be106a"></a>
 
 ## Message Flagging/Sorting
 
@@ -468,7 +467,7 @@ that it could be handled more easily, or possibly allowing those messages to be
 screened further.
 
 
-<a id="org3f453e7"></a>
+<a id="orgfbb0670"></a>
 
 ## Postage
 
@@ -494,17 +493,22 @@ messages, we would encourage that implementers of this idea be focused on
 like Hashcash are easy to implement, without adding a direct benefit to the
 receiver, they require the sender to expend resources. If extrapolated to a
 large scale, this could have a negative environmental impact due to wasted
-computing resources. It should also be noted that due to currency and cost of
-living differences, any form of fee whether paid directly or indirectly, will
+computing resources.
+
+The issues around "real currency" are far more complex. Issuing a postage fee
+based in actual currency more accurately reflects the cost of handling incoming
+spam and by virtue of requiring actual money, makes sending out mass
+solicitation or scambait email more costly. At the same time, by virtue of cost
+of living differences any form of fee whether paid directly or indirectly, will
 have a correspondingly different financial impact with greater proportional
 cost born by those in poorer countries.
 
-Because of these issues and the spirit of free communication, we would
+Because of these concerns and the spirit of free communication, we would
 encourage any implementation of this technique to be used sparingly and only on
 the first message of a new sender, rather than on all messages.
 
 
-<a id="org80ac7b7"></a>
+<a id="orgf071be6"></a>
 
 ## Bounce Messages
 
@@ -520,7 +524,7 @@ client, allowing an ActivityPub server administrator the opportunity to see why
 messages are failing and take appropriate action.
 
 
-<a id="orgdb20ba4"></a>
+<a id="org30bcaa0"></a>
 
 ## Promises
 
@@ -531,11 +535,11 @@ status of message delivery which could then be queried at a later time to
 determine if the message was delivered successfully or rejected.
 
 These Promise statuses could use the same error codes as discussed in the
-section on Bounce Messages ([3.13](#org80ac7b7)) but not be required to keep the
+section on Bounce Messages ([3.13](#orgf071be6)) but not be required to keep the
 HTTP connection open during the determination of message suitability.
 
 
-<a id="orgbcae480"></a>
+<a id="org408aace"></a>
 
 # Combining Techniques
 
@@ -545,11 +549,11 @@ MultiBox used in conjunction with Object Capabilities Inboxes allows for
 per-Actor filtering to be performed more easily. OCAP Inboxes may also be
 granted which allow a sender to bypass other filters, acting effectively as an
 Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
-explored ACL vs OCAP inReplyTo functionality in [3.8](#orge8883d9), and
+explored ACL vs OCAP inReplyTo functionality in [3.8](#orge622c90), and
 either of these techniques could be combined with content analysis.
 
 
-<a id="org872e81a"></a>
+<a id="orgc186969"></a>
 
 # A Note for ActivityPub Node Operators
 
@@ -570,7 +574,7 @@ We have not addressed this issue in this paper but believe that the topic
 deserves further research.
 
 
-<a id="org09ba1e0"></a>
+<a id="orgb3c34e7"></a>
 
 # Conclusion
 
@@ -582,7 +586,7 @@ Capabilities Inboxes allows for per-Actor filtering to be performed more
 easily. OCAP Inboxes may also be granted which allow a sender to bypass other
 filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
 may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
-[3.8](#orge8883d9), and either of these techniques could be combined with
+[3.8](#orge622c90), and either of these techniques could be combined with
 content analysis.
 
 We believe that the problem of unwanted messages is addressable and we look

--- a/topics-and-advance-readings/ap-unwanted-messages.md
+++ b/topics-and-advance-readings/ap-unwanted-messages.md
@@ -1,32 +1,30 @@
 
 # Table of Contents
 
-1.  [Introduction](#org5add05a)
-2.  [ActivityPub Overview](#org1929d17)
-3.  [Proposed Solutions](#org62c38c0)
-    1.  [Enhanced Privacy of Followers/Following Collection](#org088cba8)
-    2.  [Strict Protocol Adherence](#orge014dfd)
-    3.  [Object-Capabilities Based Inboxes](#org2e21bea)
-    4.  [MultiBox](#org01e5593)
-    5.  [Multiple Inboxes/Message Sorting](#org5e8e38a)
-    6.  [Sender Identification and Pet Names](#org6ab3d8a)
-    7.  [Blacklists](#orgff8373c)
-        1.  [Caution and Conclusions](#org5e44ee7)
-    8.  [Closing the Relay Hole](#orga9aeacc)
-    9.  [Content Based Filtering](#org912102f)
-    10. [Whitelists](#org21c8b9f)
-    11. [Message Flagging/Sorting](#org1920bd4)
-    12. [Postage](#orgdd78757)
-    13. [Bounce Messages](#org8fee336)
-    14. [Promises](#org6d9b938)
-4.  [Combining Techniques](#org559f6a7)
-5.  [A Note for ActivityPub Node Operators](#org0f0532f)
-6.  [Conclusion](#orgcb16a86)
-7.  [Endnotes](#org00aa5bc)
+1.  [Introduction](#orged105b0)
+2.  [ActivityPub Overview](#org0afa829)
+3.  [Proposed Suggestions](#orgda828b1)
+    1.  [Enhanced Privacy of Followers/Following Collection](#org3c24fd4)
+    2.  [Strict Protocol Adherence](#orgaed1764)
+    3.  [Object-Capabilities Based Inboxes](#orga30d83f)
+    4.  [MultiBox](#orgce9d54a)
+    5.  [Multiple Inboxes/Message Sorting](#org16f16a6)
+    6.  [Sender Identification and Pet Names](#org8370e97)
+    7.  [Blacklists](#org6560321)
+    8.  [Closing the Relay Hole](#org8998be3)
+    9.  [Content Based Filtering](#org4f3df99)
+    10. [Whitelists](#org62e755c)
+    11. [Message Flagging/Sorting](#org942dfbd)
+    12. [Postage](#orgc19ec55)
+    13. [Bounce Messages](#org6794f06)
+    14. [Promises](#orga78d9a1)
+4.  [Combining Techniques](#org8919757)
+5.  [A Note for ActivityPub Node Operators](#org341a92e)
+6.  [Conclusion](#org18eb43c)
 
 
 
-<a id="org5add05a"></a>
+<a id="orged105b0"></a>
 
 # Introduction
 
@@ -42,7 +40,7 @@ user accounts on the Fediverse spread across approximately 5,400 nodes.<sup><a i
 Despite this large number, unwanted messages have not yet become a widespread
 problem. It seems inevitable that given the size and breath of the Fediverse,
 along with its decentralized architecture that the introduction of unwanted
-messages is possibly inevitable.
+messages is inevitable.
 
 What exactly constitutes unwanted messages will vary from person and community
 but we generally feel these messages fall into one or more of the following
@@ -61,7 +59,7 @@ multiple domains of messages, regardless of content or whether the messages are
 meant for a public or private audience.
 
 
-<a id="org1929d17"></a>
+<a id="org0afa829"></a>
 
 # ActivityPub Overview
 
@@ -95,12 +93,12 @@ Actor Object. Requests made on behalf of that actor are then signed using the
 Actor's private key and may be verified against its public key.
 
 
-<a id="org62c38c0"></a>
+<a id="orgda828b1"></a>
 
-# Proposed Solutions
+# Proposed Suggestions
 
 
-<a id="org088cba8"></a>
+<a id="org3c24fd4"></a>
 
 ## Enhanced Privacy of Followers/Following Collection
 
@@ -114,7 +112,7 @@ be disclosed to a third party or only be disclosed insofar as it related to the
 actor making the request.
 
 
-<a id="orge014dfd"></a>
+<a id="orgaed1764"></a>
 
 ## Strict Protocol Adherence
 
@@ -146,7 +144,7 @@ Nonetheless, we mention this method because it has been so effective in email,
 and thus may be something to evaluate again in the future.
 
 
-<a id="org2e21bea"></a>
+<a id="orga30d83f"></a>
 
 ## Object-Capabilities Based Inboxes
 
@@ -195,7 +193,7 @@ endpoint as discussed previously. In such cases, a server would need to
 retrieve a new Inbox for an Actor as needed.
 
 
-<a id="org01e5593"></a>
+<a id="orgce9d54a"></a>
 
 ## MultiBox
 
@@ -218,9 +216,11 @@ separated values<sup><a id="fnr.11" class="footref" href="#fn.11">11</a></sup>.
 
 This has two advantages over Shared Inbox. Used on its own, it eliminates the
 vulnerability mentioned previously whereby recipients to a message do not need
-to be listed. If this proposal is adopted alongside the [3.3](#org2e21bea) proposal, the advantages multiply as we also gain the ability to
-appropriately filter incoming messages according to the criteria set out by the
-specific Inboxes, as well as letting us know the origin of each Inbox. 
+to be listed. If this proposal is adopted alongside the Object-Capabilities
+Based Inbox proposal ([3.3](#orga30d83f)), the
+advantages multiply as we also gain the ability to appropriately filter
+incoming messages according to the criteria set out by the specific Inboxes, as
+well as letting us know the origin of each Inbox.
 
 For the sender, the additional computing resources required to send a MultiBox
 request are minimal, but doing so would make mass-messages expensive for
@@ -236,7 +236,7 @@ This would limit the number of per message recipients, though this limitation
  `MultiBox` object encapsulating the `Audience` field and the ~Activity.
 
 
-<a id="org5e8e38a"></a>
+<a id="org16f16a6"></a>
 
 ## Multiple Inboxes/Message Sorting
 
@@ -254,11 +254,13 @@ communication) but only through the Client to Server (C2S) communication
 protocol dictated in the ActivityPub standard.<sup><a id="fnr.13" class="footref" href="#fn.13">13</a></sup>
 
 A variety of techniques could be employed when sorting messages, including but
-not limited to the content based filtering techniques described in [3.9](#org912102f) or using [3.3](#org2e21bea) mechanisms described
-in this whitepaper.
+not limited to the content based filtering techniques described in previous
+sections about filtering based on message content ([3.9](#org4f3df99)) or
+using OCAP Inboxes ([3.3](#orga30d83f)) described in this
+whitepaper.
 
 
-<a id="org6ab3d8a"></a>
+<a id="org8370e97"></a>
 
 ## Sender Identification and Pet Names
 
@@ -291,7 +293,8 @@ then we know that there is some level of communication between them, thereby
 indicating that the communication is more likely to be useful.
 
 We recognize that this proposal may seem in contrast to the previous proposal
-of not disclosing connections to third parties as described in [3.1](#org088cba8), but the two can operate in tandem by making
+of not disclosing connections to third parties as described in the section on
+improving privacy of Follower/Following Collections ([3.1](#org3c24fd4)), but the two can operate in tandem by making
 the ability to find a connection to your followers be a query, rather than a
 publicly available list. We could further enhance the security of this by
 adding additional restrictions onto the query functionality such as rate
@@ -303,7 +306,7 @@ believe that this would require further examination in order to be done in a
 way that protects a user's social graph.
 
 
-<a id="orgff8373c"></a>
+<a id="org6560321"></a>
 
 ## Blacklists
 
@@ -317,7 +320,7 @@ In ActivityPub an individual Actor or server administrator may choose to create
 a custom blocklist, but there is currently no standardized way to distribute or
 share blocklists. We propose that this be explored further, though cautiously
 by allowing Actors to query each other's either mute or block lists through a
-mechanism similar to the proposal described in [3.6](#org6ab3d8a).
+mechanism similar to the proposal described in the section on Pet Names ([3.6](#org8370e97)).
 
 Actors who have agreed to peer with each other in regards to shared mute or
 block lists will be given an additional property in their actor object
@@ -325,11 +328,6 @@ corresponding to a query endpoint for their blocklists, thus creating
 functionality where these lists can be shared between actors. These blocklists
 may contain either actor level or server level bans, and could additionally be
 shared between server administrators.
-
-
-<a id="org5e44ee7"></a>
-
-### Caution and Conclusions
 
 We believe that while blocklists may be effective in addressing some types of
 unwanted messages, particularly offensive speech, that they carry with them a
@@ -349,8 +347,7 @@ miss out on messages that they might wish to recieve. The analogy of adblocking
 software is often used by those supporting this type of proposal, but in
 ad-blocking, it is possible to disable the software selectively when the
 functionality of a website does not work. With blocklists, unless they are
-paired with another proposal, such as [3.5](#org5e8e38a), they
-may have the consequence of breaking federation.
+paired with another proposal, such as the one about multiple inboxes ([3.5](#org16f16a6)), they may have the consequence of breaking federation.
 
 Thirdly, the mechanism described precludes the ability to easily remove a
 block. If a block is removed, there is no mechanism that allows those who have
@@ -365,7 +362,7 @@ unwanted messages, unless we can address the concerns raised above, we cannot
 endorse their deployment.
 
 
-<a id="orga9aeacc"></a>
+<a id="org8998be3"></a>
 
 ## Closing the Relay Hole
 
@@ -384,9 +381,9 @@ because the replier does not send the message to everyone that the original
 sender did. Unfortunately this also opens up replies as a vector of abuse in
 that a malicious sender may simply reply to an existing message, at which point
 the sender of the original message will relay the reply to all their Followers
-and any other audience of message.We suggest two solutions to this problem, one
-using traditional Access Control Lists and the other using the Object
-Capabilities Inbox proposal.
+and any other audience of message. We suggest two methods to address this
+problem, one using traditional Access Control Lists and the other using the
+Object Capabilities Inbox proposal.
 
 An Access Control Method solution would allow for the recipient of a
 `inReplyTo` activity to be presented with a moderator queue of Activities in
@@ -403,7 +400,7 @@ reply without moderation is given a new Inbox corresponding to this added
 capability.
 
 
-<a id="org912102f"></a>
+<a id="org4f3df99"></a>
 
 ## Content Based Filtering
 
@@ -429,7 +426,7 @@ in creating training models that work well based on community standards of
 interest and behavior.
 
 
-<a id="org21c8b9f"></a>
+<a id="org62e755c"></a>
 
 ## Whitelists
 
@@ -450,7 +447,7 @@ Such whitelists are difficult to curate and more importantly, break the spirit
 of communication that as at the heart of the protocol.
 
 
-<a id="org1920bd4"></a>
+<a id="org942dfbd"></a>
 
 ## Message Flagging/Sorting
 
@@ -471,7 +468,7 @@ that it could be handled more easily, or possibly allowing those messages to be
 screened further.
 
 
-<a id="orgdd78757"></a>
+<a id="orgc19ec55"></a>
 
 ## Postage
 
@@ -507,7 +504,7 @@ encourage any implementation of this technique to be used sparingly and only on
 the first message of a new sender, rather than on all messages.
 
 
-<a id="org8fee336"></a>
+<a id="org6794f06"></a>
 
 ## Bounce Messages
 
@@ -523,7 +520,7 @@ client, allowing an ActivityPub server administrator the opportunity to see why
 messages are failing and take appropriate action.
 
 
-<a id="org6d9b938"></a>
+<a id="orga78d9a1"></a>
 
 ## Promises
 
@@ -533,11 +530,12 @@ processing of the message asynchronously and return a Promise representing the
 status of message delivery which could then be queried at a later time to
 determine if the message was delivered successfully or rejected.
 
-These Promise statuses could use the same error codes as discussed in [3.13](#org8fee336) but not be required to keep the HTTP connection open during the
-determination of message suitability.
+These Promise statuses could use the same error codes as discussed in the
+section on Bounce Messages ([3.13](#org6794f06)) but not be required to keep the
+HTTP connection open during the determination of message suitability.
 
 
-<a id="org559f6a7"></a>
+<a id="org8919757"></a>
 
 # Combining Techniques
 
@@ -547,11 +545,11 @@ MultiBox used in conjunction with Object Capabilities Inboxes allows for
 per-Actor filtering to be performed more easily. OCAP Inboxes may also be
 granted which allow a sender to bypass other filters, acting effectively as an
 Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
-explored ACL vs OCAP inReplyTo functionality in [3.8](#orga9aeacc), and
+explored ACL vs OCAP inReplyTo functionality in [3.8](#org8998be3), and
 either of these techniques could be combined with content analysis.
 
 
-<a id="org0f0532f"></a>
+<a id="org341a92e"></a>
 
 # A Note for ActivityPub Node Operators
 
@@ -572,7 +570,7 @@ We have not addressed this issue in this paper but believe that the topic
 deserves further research.
 
 
-<a id="orgcb16a86"></a>
+<a id="org18eb43c"></a>
 
 # Conclusion
 
@@ -584,16 +582,11 @@ Capabilities Inboxes allows for per-Actor filtering to be performed more
 easily. OCAP Inboxes may also be granted which allow a sender to bypass other
 filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
 may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
-[3.8](#orga9aeacc), and either of these techniques could be combined with
+[3.8](#org8998be3), and either of these techniques could be combined with
 content analysis.
 
 We believe that the problem of unwanted messages is addressable and we look
 forward to participating in building solutions.
-
-
-<a id="org00aa5bc"></a>
-
-# Endnotes
 
 
 # Footnotes

--- a/topics-and-advance-readings/ap-unwanted-messages.org
+++ b/topics-and-advance-readings/ap-unwanted-messages.org
@@ -1,0 +1,572 @@
+#+TITLE: Keeping Unwanted Messages Off the Fediverse
+#+AUTHOR: Serge Wroclawski with advice and ideas from  Christopher Lemmer Webber
+
+#+LANGUAGE: en
+#+LATEX_HEADER: \usepackage{endnotes}
+#+LATEX_HEADER: \let\footnote=\endnote
+#+LaTeX_HEADER: \renewcommand{\notesname}{}
+#+LATEX_HEADER: \usepackage{float}
+#+LATEX_HEADER: \floatstyle{boxed}
+
+* Introduction
+
+Unwanted messages are a challenge for all public communication systems. On a
+federated network without a central form of control, the challenge is extended
+to allowing for free communication between parties without a central means of
+control while at the same time preventing undesired or harmful messages.
+
+ActivityPub[fn:18] is a W3C standard protocol designed to facilitate social
+networks. The aggregate name for systems that use the ActivityPub is the
+Fediverse. As of the time of publication, there are approximately three million
+user accounts on the Fediverse spread across approximately 5,400 nodes.[fn:19]
+Despite this large number, unwanted messages have not yet become a widespread
+problem. It seems inevitable that given the size and breath of the Fediverse,
+along with its decentralized architecture that the introduction of unwanted
+messages is inevitable.
+
+# NOTE: Do we want to be explicit about unwanted messages?
+What exactly constitutes unwanted messages will vary from person and community
+but we generally feel these messages fall into one or more of the following
+categories: Unsolicited commercial messages (spam), messages designed to commit
+fraud (scams, phishing), messages designed to harm or inflame (trolling),
+messages designed to harm, intimidate or coerce (bullying), abusive or
+threatening speech against a particular group (hate speech), messages
+containing deliberate disinformation (fake news), or messages of an
+inappropriate nature for community standards (eg violence or pornography). We
+do not define these terms further nor do we believe in a universal enforcement
+of any one set of community standards, instead we rely on each node and
+community to define these standards for themselves.
+
+The techniques described in this paper are generalized and could be used across
+multiple domains of messages, regardless of content or whether the messages are
+meant for a public or private audience.
+
+* ActivityPub Overview
+
+ActivityPub is an HTTP based messaging system that allows for seamless cross
+server communication (aka federation). In ActivityPub, individual accounts
+called =Actors= are addressed by unique URN identifiers. Messages between
+Actors are serialized using an extension of the Activity Streams
+specification[fn:20]. These messages are called Activities. Each Activity is
+composed of three parts:: The =Actor= originating the Activity, an =Activity
+Type= representing the action being taken and an =Object=. Objects are the core
+type in ActivityPub and may represent any noun in the system. Activities and
+Objects are referenced by URN as unique identifiers. Activities also have an
+audience field, which is a list of Actors which should have access to the
+Activity.
+
+Actor to Actor communication vaguely resembles email. Each =Actor='s URN
+resolved to their =Actor Object= which specifies that messages destined to a
+specific Actor be delivered to its =Inbox=, a URN that is meant to receive such
+messages from external parties. ActivityPub also specifies an =Outbox= where
+outgoing messages are posted in a manner similar to RSS/Atom feeds, but using
+the Activity Streams vocabulary and reliant on authentication to ensure
+messages are only seen by those who have authority to do so. In addition to
+these delivery mechanisms, ActivityPub also specifies an optional =sharedInbox=
+where either multiple actors may be listed explicitly or where messages to
+multiple recipients may be interpreted by the receiving server implicitly.
+
+While not directly part of the standard, HTTP Signatures[fn:3] are most
+commonly used with ActivityPub as the authentication mechanism. Actors have a
+generated keypair and their public keys are displayed on the aforementioned
+Actor Object. Requests made on behalf of that actor are then signed using the
+Actor's private key and may be verified against its public key.
+
+* Proposed Suggestions
+
+** Enhanced Privacy of Followers/Following Collection
+
+One of the tools of spammers is to collect as many contacts as possible. For a
+sophisticated attacker, the connections between contacts could be used to
+violate someone's privacy or as part of a sophisticated phishing or scamming
+attempt. Due to these and other concerns over sensitive information leaking to
+third parties, we suggest that =Followers= and =Following= collections not
+generally be made public. Instead, such private information should either never
+be disclosed to a third party or only be disclosed insofar as it related to the
+actor making the request.
+
+** Strict Protocol Adherence
+
+Postel's law states that a protocol implementer should be strict in what they
+send and liberal in what they accept.[fn:15]. At the same time, email operators
+have found that many spammers' servers do not adhere strictly to the SMTP
+protocol. As an example, many mail servers lack a Forward-Confirmed Reverse DNS
+record[fn:5] or send a HELO/EHLO that is not a fully qualified domain name or
+does not match the sender[fn:6]. Many such servers also lack the ability to
+retry messages in the case of temporary failure, a situation that is utilized
+in greylisting[fn:7]. Because of this pattern of non-compliance, one common
+technique to reduce spam in email is to find the areas of the protocol that are
+commonly skipped by spammers and either block access or restrict access based
+on non-compliance.
+
+It remains an open question on whether ActivityPub operator should take the
+same approach regarding federating with other ActivityPub servers. We do not
+believe that at this time such an approach is necessary or desirable. The
+approach of being strict in what one accepts from other servers was born out of
+necessity by email operators who found correlations between poor
+implementations and unwanted messages. While these correlations are undeniable,
+they are not causal nor directly associated except in that requiring strict
+adherence raised the bar for all email administrators, making it more
+challenging to run a mail server. Especially as it relates to PTR records, this
+prevented anyone who was not directly in a business relationship with their
+upstream provider to be able to operate a mail server. We do not believe that
+all ActivityPub servers should be required to keep to such strict standards.
+Nonetheless, we mention this method because it has been so effective in email,
+and thus may be something to evaluate again in the future.
+
+** Object-Capabilities Based Inboxes
+
+As per the ActivityPub specification, every =Actor= is required to have an
+associated =Inbox=. In most ActivityPub implementations, an Actor's inbox is
+simply a URL endpoint specific to the actor, e.g.
+=https://example.com/bob/inbox=. While convenient, we propose that servers
+should be using Object Capabilities model by which Inboxes are a capability
+handed out by a server.
+
+Without delving too far into the theory of object capabilities, we can imagine
+that the ability to send a message from one Actor to another is an action that
+we can grant explicit access to similarly to the way that access is granted to
+an API in a computer system. In order to be able to send a message to the
+receipient, the recipient must first provide the sender with a /capability/ to
+do so. This capability can be represented as a long randomly generated string.
+Its length and randomness make it impractical to guess and thus (in OCAP
+parlance) unforgeable.
+
+This act of the sender handing out capabilities may be done in a number of
+ ways, though we suggest that offering a new Inbox could be performed as a new
+ Activity, for example:
+
+#+NAME: OCAP_Inbox
+#+BEGIN_SRC JSON
+{"@context": "...",
+ "type": "Inbox",
+ "to": ["https://chatty.example/ben/"],
+ "attributedTo": "https://social.example/alyssa/",
+ "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj]
+#+END_SRC
+
+In our example, we show multiple inboxes being delivered. As part of the Object
+Capabilities model, these capabilities are transferable, which would allow one
+actor to send an inbox capability to another actor, for example in a situation
+where the recipient is a trusted party. 
+
+If one Inbox becomes abused, we are able to trace back to exactly when and for
+who the Inbox was generated. We are also able to revoke the Inbox, stopping any
+future requests to it. An HTTP request sent to an expired Inbox should ideally
+result in an HTTP 410 (Gone)[fn:10], alerting the sending to the unavailability
+of the inbox and prompting it to request a new one if it wishes to resume
+communication.
+
+The OCAP Inbox model as described in this proposal would require little or no
+changes to existing deployed ActivityPub servers except where such servers are
+not prepared to accept a non-success (200) result when posting to an HTTP
+endpoint as discussed previously. In such cases, a server would need to
+retrieve a new Inbox for an Actor as needed.
+
+** MultiBox
+
+=Shared Inbox=[fn:11] provides the ability for server to server communication
+traffic to be reduced from R requests, where R is the number of recipients, to
+a single HTTP request. This is a desirable property as it reduces the amount of
+HTTP round trips for both the sender and receiver. Unfortunately the design of
+Shared Inboxes as described in the ActivityPub specification makes it very easy
+for a spammer to abuse the system by not requiring explicit delivery
+recipients. We propose an alternative to Shared Inbox called MultiBox that
+keeps the desirable properties of Shared Inbox while protecting against
+scenarios in which the sender uses Shared Inbox to "spam" a server.
+
+Like Shared Inbox, MultiBox consists of a single HTTP endpoint for multiple
+Actors. Unlike Shared Inbox, in a MultiBox request, each recipient is
+explicitly listed /by Inbox/, requiring both the knowledge of the Actor and a
+corresponding Inbox for that actor. This information is transmitted through the
+use of an HTTP header ~Audience~ where each Inbox is listed using comma
+separated values[fn:4].
+
+This has two advantages over Shared Inbox. Used on its own, it eliminates the
+vulnerability mentioned previously whereby recipients to a message do not need
+to be listed. If this proposal is adopted alongside the Object-Capabilities
+Based Inbox proposal ([[Object-Capabilities Based Inboxes]]), the
+advantages multiply as we also gain the ability to appropriately filter
+incoming messages according to the criteria set out by the specific Inboxes, as
+well as letting us know the origin of each Inbox.
+
+For the sender, the additional computing resources required to send a MultiBox
+request are minimal, but doing so would make mass-messages expensive for
+senders wishing to abuse the system.
+
+One open question on this proposal is that if we use the HTTP header ~Audience~
+to store the list of recipients, this may result in a limitation. HTTP header
+sizes are not explicitly capped at the protocol level but implementations often
+cap them at different lengths- 4Kb for the Nginx web server or 8Kb for Apache.
+
+This would limit the number of per message recipients, though this limitation
+ would rarely be reached. An alternative to this proposal would be a new
+ ~MultiBox~ object encapsulating the ~Audience~ field and the ~Activity.
+
+** Multiple Inboxes/Message Sorting
+
+The ActivityPub protocol specifies an ~Inbox~ collection[fn:12] to store
+incoming messages for the Actor. This functions similarly to the common Email
+Inbox where by default, messages arrive. As thinking regarding email has
+evolved, automatic message sorting has been employed using either actual
+folders or tagging mechanisms. These same techniques could be applied to
+ActivityPub, whereby a message could be placed in an Inbox collection
+corresponding to sorting rules.
+
+This extension to the ActivityPub protocol would not have to be visible to any
+external entities (ie not accessible through the Server-To-Server
+communication) but only through the Client to Server (C2S) communication
+protocol dictated in the ActivityPub standard.[fn:13]
+
+A variety of techniques could be employed when sorting messages, including but
+not limited to the content based filtering techniques described in previous
+sections about filtering based on message content ([[Content Based Filtering]]) or
+using OCAP Inboxes ([[Object-Capabilities Based Inboxes]]) described in this
+whitepaper.
+
+** Sender Identification and Pet Names
+
+One of the most critical components of reducing unwanted messages is the
+identification of the sender of a message. Without verification, a sender may
+use their ability to impersonate someone else for a number of purposes, from
+spamming, to bypassing security or scamming, often referred to in the
+literature as either /Joe Jobbing/ or /Phishing/.
+
+In Email, verification is largely achieved by verifying that the email server
+is trusted for the domain which it purports to deliver email, often through an
+out of band technique, often involving DNS, such as SPF[fn:1] or DMIM[fn:2].
+
+In ActivityPub, sender identification is performed at the Actor level using the
+HTTP Signatures.[fn:3] With this extension, each Actor has a public and private
+keypair. The public key of an Actor may be retrieved by retrieving its Actor
+Object, a JSON-LD object retrievable by HTTP. Since ActivityPub requires Actor
+object lookups as part of normal message deliver, this is adds only a minimal
+amount of additional work on the receiver's part. Each message sent on behalf
+of an Actor is signed at the HTTP level by this key, which can then be verified
+by the receiving server for authenticity.
+
+We propose to extend this validation with a second layer of identity validation
+through the use of Pet Names. The Pet Names proposal presented in Rebooting Web
+of Trust 2018[fn:14] has a secondary property of being able to be used as
+simplified trust mechanism. When a sender would like to make contact with a
+receiver, the receiver checks its neighbors (Followers or Following) for a pet
+name for this sender. If a neighbor has decided to give this sender a Pet Name,
+then we know that there is some level of communication between them, thereby
+indicating that the communication is more likely to be useful.
+
+We recognize that this proposal may seem in contrast to the previous proposal
+of not disclosing connections to third parties as described in the section on
+improving privacy of Follower/Following Collections ([[Enhanced Privacy of
+Followers/Following Collection]]), but the two can operate in tandem by making
+the ability to find a connection to your followers be a query, rather than a
+publicly available list. We could further enhance the security of this by
+adding additional restrictions onto the query functionality such as rate
+limiting queries.
+
+We further recognize that this is not a full Web of Trust system in that webs
+of trust extend beyond one hop. It would be possible do so here as well, but we
+believe that this would require further examination in order to be done in a
+way that protects a user's social graph.
+
+** Blacklists
+
+A blacklist is a list or searchable collection of entities which should be
+distrusted. Blacklists are widely used by many email administrators to prevent
+email originating from one or more types of sources that they distrust, such as
+mail servers residing on consumer grade Internet connections or mail servers
+that have been known to send spam recently.
+
+In ActivityPub an individual Actor or server administrator may choose to create
+a custom blocklist, but there is currently no standardized way to distribute or
+share blocklists. We propose that this be explored further, though cautiously
+by allowing Actors to query each other's either mute or block lists through a
+mechanism similar to the proposal described in the section on Pet Names ([[Sender
+Identification and Pet Names]]).
+
+Actors who have agreed to peer with each other in regards to shared mute or
+block lists will be given an additional property in their actor object
+corresponding to a query endpoint for their blocklists, thus creating
+functionality where these lists can be shared between actors. These blocklists
+may contain either actor level or server level bans, and could additionally be
+shared between server administrators.
+
+We believe that while blocklists may be effective in addressing some types of
+unwanted messages, particularly offensive speech, that they carry with them a
+number of caveats that give us pause in wholeheartedly endorsing this
+mechanism.
+
+Firstly, should a malicious party gain access to a blocklist, this could
+potentially create a situation in the originator would be made a target for
+attack. We believe that using a query service, rather than a list, mitigates
+this concern somewhat, but it would be possible for an a malicious party to
+covertly build up such a list and use it to create a list of targets.
+
+Secondly, we are concerned that the transitive properties of block lists may
+have unintended consequences or be used as a vector for attack or denial of
+service. If services adopt each other's blocklists without review, they may
+miss out on messages that they might wish to recieve. The analogy of adblocking
+software is often used by those supporting this type of proposal, but in
+ad-blocking, it is possible to disable the software selectively when the
+functionality of a website does not work. With blocklists, unless they are
+paired with another proposal, such as the one about multiple inboxes ([[Multiple
+Inboxes/Message Sorting]]), they may have the consequence of breaking federation.
+
+Thirdly, the mechanism described precludes the ability to easily remove a
+block. If a block is removed, there is no mechanism that allows those who have
+previously queried the blocklist to be notified. This problem is made worse if
+blocklists are transitive. It would be possible to replace a query based
+mechanism with a subscription based mechanism, but doing so would be subject to
+the concern raised previously about blocklists being used to target
+individuals.
+
+While we believe blocklists may be an effective strategy to block some types of
+unwanted messages, unless we can address the concerns raised above, we cannot
+endorse their deployment.
+
+** Closing the Relay Hole
+
+Message Relaying involves sending a a message on behalf of another entity.
+Message relaying is common in Store-and-Forward network designs. In Email, it
+was common for servers to be offline some or most of the time, requiring that
+other servers acted as relays, either sending or accepting mail on their behalf
+cooperatively. In time, spammers began abusing these servers in order to send
+messages on their behalf. Because of this, many mail servers block "Open Mail
+Relays".
+
+In ActivityPub, message relaying is performed in accordance with Section 7.1.2
+of the ActivityPub specification[fn:4] in order to mitigate the "Ghost Replies"
+problem, where a rely to a message is not seen by everyone watching that thread
+because the replier does not send the message to everyone that the original
+sender did. Unfortunately this also opens up replies as a vector of abuse in
+that a malicious sender may simply reply to an existing message, at which point
+the sender of the original message will relay the reply to all their Followers
+and any other audience of message. We suggest two methods to address this
+problem, one using traditional Access Control Lists and the other using the
+Object Capabilities Inbox proposal.
+
+An Access Control Method solution would allow for the recipient of a
+~inReplyTo~ activity to be presented with a moderator queue of Activities in
+reply to their own, which they then may act on. If they accept the reply, the
+recipient will then send messages on behalf of the sender to their Followers.
+The recipient Actor may also decide on a policy regarding future replies from
+the same actor. For example, they may decide that future messages from that
+Actor need not be moderated, effectively granting them access to the relay
+functionality.
+
+An alternative method using the OCAP model would be to treat replies as a
+capability provided to by some Inboxes. An Actor who is then granted access to
+reply without moderation is given a new Inbox corresponding to this added
+capability.
+
+** Content Based Filtering
+
+While the other methods of message filtering address external signifiers of
+unwanted messages, content-based filtering looks directly at content of the
+messages themselves, either by lists of common terms found in unwanted
+messages, by evaluating the probability of messages being unwanted or by
+looking for other signifiers such as messages that appear to be phishing
+attempts.
+
+Content based filtering can take many forms, from simple rule based filters, to
+Baysean text analysis[fn:9], sentiment analysis or even more complex image
+classification.
+
+An exciting area of further exploration may be the use of Federated
+Learning[fn:16], whereby training can be performed in a way that allows
+individual data to be kept private but the results may be shared and built
+upon.
+
+We offer no specific technique or method for this suggestion but do think that
+the benefits of existing "theme based" ActivityPub services may be beneficial
+in creating training models that work well based on community standards of
+interest and behavior.
+
+** Whitelists
+
+Another approach to handling unwanted messages is the use of whitelists.
+Whitelists as used in email most often simply bypass other measures when the
+sender identifies themselves as an entity on the whitelist. Whitelists in email
+are almost always a result of missclassification of messages as spam. While
+this may have applicability on the Actor level, we believe that the use of
+server whitelists in ActivityPub should be limited.
+
+Whitelists have been proposed on the ActivityPub Fediverse as a means of
+ensuring that mutual agreements between nodes are enforced. This approach is
+akin to an email provider that only explicitly allows messages from large well
+known organizations, for example by Google or Hotmail, and does not allow them
+from anyone else, including Universities or Non-Profits.
+
+Such whitelists are difficult to curate and more importantly, break the spirit
+of communication that as at the heart of the protocol.
+
+** Message Flagging/Sorting
+
+A simple approach to the issue of unwanted messages is to mark suspicious
+messages as such and place them outside of the normal message retrieval- either
+in a separate Inbox (eg a Spam Folder) or on another system altogether in
+"Quarantine". These same principles could be applied to ActivityPub by
+extending a single Inbox to multiple incoming Collections, each containing
+some subset of messages based on multiple analysis.
+
+Such collections could be presented to the end user in a number of ways, using
+the analogy of Tagging or directly as separate collections. We believe that
+separating out the collections has a secondary benefit of allowing the
+individual user to be prepared for either irrelevant or offensive content. For
+example, an Inbox collection labeled "Warning" may allow for sufficient
+emotional distance from the content such that even if a message is offensive
+that it could be handled more easily, or possibly allowing those messages to be
+screened further.
+
+** Postage
+
+All techniques used to identify and either block or sort unwanted messages
+exist because there are costs in handling such messages. These costs are
+bandwidth, electricity and storage, but also our valuable time and mental
+health. Rather than create techniques that place even greater cost on the
+receiver, it is possible to assign a cost value of sending messages to the
+sender.
+
+By requiring that the sender pay a cost, we shift the decision of whether or
+not a message is worth sending to the sender. rather than the recipient. As is
+shown by physical "Junk Mail", this does not necessarily eliminate all unwanted
+messages, but it does reduce incentive. The fee of sending messages could be
+paid in any number of ways, from systems such as with Hashcash[fn:17], paid
+with digital currency, or part of another system, such as requiring a sender to
+perform computational or storage tasks on behalf of the sender.
+
+Requiring the message sender to expend resources in terms of either work or
+currency has a number of benefits in reducing the incentive to send unwanted
+messages, we would encourage that implementers of this idea be focused on
+"fees" that that directly benefit the receiver. While proof of work systems
+like Hashcash are easy to implement, without adding a direct benefit to the
+receiver, they require the sender to expend resources. If extrapolated to a
+large scale, this could have a negative environmental impact due to wasted
+computing resources. It should also be noted that due to currency and cost of
+living differences, any form of fee whether paid directly or indirectly, will
+have a correspondingly different financial impact with greater proportional
+cost born by those in poorer countries.
+
+Because of these issues and the spirit of free communication, we would
+encourage any implementation of this technique to be used sparingly and only on
+the first message of a new sender, rather than on all messages.
+
+** Bounce Messages
+
+The ActivityPub specification does not address a situation in which messages
+are rejected. While not strictly necessary, providing bounce messages does
+allow for well meaning server administrators to have an understanding of why
+their users' messages are not being delivered. We recommend an extension of the
+HTTP status codes to include a new "Not Accepted" status code representing the
+receipt of a request that is properly formatted but not accepted by the server
+by a reason not covered by one of the other methods. A textual or JSON
+representation of the full error message could then be provided to the HTTP
+client, allowing an ActivityPub server administrator the opportunity to see why
+messages are failing and take appropriate action.
+
+** Promises
+
+Because many of the techniques discussed in this proposal are expensive to
+perform, we suggest that in some cases a server may wish to handle the
+processing of the message asynchronously and return a Promise representing the
+status of message delivery which could then be queried at a later time to
+determine if the message was delivered successfully or rejected.
+
+These Promise statuses could use the same error codes as discussed in the
+section on Bounce Messages ([[Bounce Messages]]) but not be required to keep the
+HTTP connection open during the determination of message suitability.
+
+* Combining Techniques
+
+As emphasized previously, the suggestions made in this proposal are meant to be
+used in conjunction with one another for maximum efficacy. For example,
+MultiBox used in conjunction with Object Capabilities Inboxes allows for
+per-Actor filtering to be performed more easily. OCAP Inboxes may also be
+granted which allow a sender to bypass other filters, acting effectively as an
+Actor Whitelist, whereas a "Default Inbox" may require a postage fee. We
+explored ACL vs OCAP inReplyTo functionality in [[Closing the Relay Hole]], and
+either of these techniques could be combined with content analysis.
+
+
+* A Note for ActivityPub Node Operators
+
+During the research for this paper, the author asked ActivityPub node operators
+what their experiences were with spammers and we received information that
+spammers were signing up for accounts on nodes. This presents a challenge to
+all parties involved.
+
+Many of the techniques in this document have been optimized for a scenario in
+which a spammer is operating their own servers. Understanding that spammers are
+attempting to use existing nodes makes the situation for those node operators
+more challenging as blocks may apply to an entire node. Therefore it becomes
+imperative for those who run nodes on the Fediverse to do their best not only
+to block incoming messages but to monitor their nodes for abusive behavior by
+their users.
+
+We have not addressed this issue in this paper but believe that the topic
+deserves further research.
+
+
+* Conclusion
+
+In this paper, we have presented a number of techniques for keeping unwanted
+messages off an ActivityPub server. As emphasized previously, the suggestions
+made in this proposal are meant to be used in conjunction with one another for
+maximum efficacy. For example, MultiBox used in conjunction with Object
+Capabilities Inboxes allows for per-Actor filtering to be performed more
+easily. OCAP Inboxes may also be granted which allow a sender to bypass other
+filters, acting effectively as an Actor Whitelist, whereas a "Default Inbox"
+may require a postage fee. We explored ACL vs OCAP inReplyTo functionality in
+[[Closing the Relay Hole]], and either of these techniques could be combined with
+content analysis.
+
+We believe that the problem of unwanted messages is addressable and we look
+forward to participating in building solutions.
+
+* Footnotes
+
+[fn:20] https://www.w3.org/TR/activitystreams-core/
+
+[fn:19] https://the-federation.info/
+
+[fn:18] https://www.w3.org/TR/activitypub/
+
+[fn:17] http://www.hashcash.org/
+
+[fn:16] https://federated.withgoogle.com/
+
+[fn:15] https://en.wikipedia.org/wiki/Robustness_principle
+
+[fn:14] https://github.com/cwebber/rebooting-the-web-of-trust-spring2018/blob/petnames/topics-and-advance-readings/petnames.md
+
+[fn:13] https://www.w3.org/TR/activitypub/#client-to-server-interactions
+
+[fn:12] https://www.w3.org/TR/activitypub/#inbox
+
+[fn:11] https://www.w3.org/TR/activitypub/#shared-inbox-delivery
+
+[fn:10] https://tools.ietf.org/html/rfc7231#section-6.5.9
+
+[fn:9] http://www.paulgraham.com/spam.html
+
+[fn:8] https://www.w3.org/TR/activitypub/#retrieving-objects
+
+[fn:7] https://www.greylisting.org/
+
+[fn:6] https://tools.ietf.org/html/rfc5321
+
+[fn:5] https://www.rfc-editor.org/std/std13.txt
+
+[fn:4] https://www.w3.org/TR/activitypub/#inbox-forwarding
+
+[fn:3] https://www.w3.org/wiki/SocialCG/ActivityPub/Authentication_Authorization#Signing_requests_using_HTTP_Signatures
+
+[fn:2] http://dkim.org/
+
+[fn:1] http://www.openspf.org/
+
+#+LaTeX: \begingroup
+#+LaTeX: \parindent 0pt
+#+LaTeX: \parskip 2ex
+#+LaTeX: \def\enotesize{\normalize}
+#+LaTeX: \theendnotes
+#+LaTeX: \endgroup

--- a/topics-and-advance-readings/ap-unwanted-messages.org
+++ b/topics-and-advance-readings/ap-unwanted-messages.org
@@ -72,7 +72,29 @@ generated keypair and their public keys are displayed on the aforementioned
 Actor Object. Requests made on behalf of that actor are then signed using the
 Actor's private key and may be verified against its public key.
 
+* The Fediverse Today and Unwanted Messages
+
 * Proposed Suggestions
+
+** Mandatory Activity and Object Validation
+
+The ActivityPub standard itself provides only basic guidelines into validation
+of messages but does recommend verifying external objects and activities as a
+base minimum mechanism against spoofed messages.[fn:21] Based on anecdotes from
+operators on the Fediverse, this technique alone has been effective in either
+the case of spoofed messages or the case where an account has been created,
+sends messages and is then shut down for abuse. In either case, we recommend
+that all ActivityPub implementations validate Activities and Objects in order
+to eliminate this unwanted message vector.
+
+** HTTP Signature Validation
+
+The HTTP Signatures extension, while not officially part of the ActivityPub
+standard has been acting as a de-facto standard for authentication on the
+Fediverse. We recommend that unless and until another authentication mechanism
+offering the same benefits as HTTP Signatures becomes available and generally
+adopted that HTTP Signatures be implemented in ActivityPub software and HTTP
+Signature validation of messages should then be assumed.
 
 ** Enhanced Privacy of Followers/Following Collection
 
@@ -527,6 +549,8 @@ We believe that the problem of unwanted messages is addressable and we look
 forward to participating in building solutions.
 
 * Footnotes
+
+[fn:21] https://www.w3.org/TR/activitypub/#obj
 
 [fn:20] https://www.w3.org/TR/activitystreams-core/
 

--- a/topics-and-advance-readings/ap-unwanted-messages.org
+++ b/topics-and-advance-readings/ap-unwanted-messages.org
@@ -142,13 +142,13 @@ This act of the sender handing out capabilities may be done in a number of
  "type": "Inbox",
  "to": ["https://chatty.example/ben/"],
  "attributedTo": "https://social.example/alyssa/",
- "alternativeInbox ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
+ "preferredInbox ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
 #+END_SRC
 
-In our example, we show multiple inboxes being delivered. As part of the Object
+In our example, we show multiple inboxes being offered. As part of the Object
 Capabilities model, these capabilities are transferable, which would allow one
 actor to send an inbox capability to another actor, for example in a situation
-where the recipient is a trusted party. 
+where the recipient is a trusted party.
 
 If one Inbox becomes abused, we are able to trace back to exactly when and for
 who the Inbox was generated. We are also able to revoke the Inbox, stopping any
@@ -158,10 +158,9 @@ of the inbox and prompting it to request a new one if it wishes to resume
 communication.
 
 The OCAP Inbox model as described in this proposal would require little or no
-changes to existing deployed ActivityPub servers except where such servers are
-not prepared to accept a non-success (200) result when posting to an HTTP
-endpoint as discussed previously. In such cases, a server would need to
-retrieve a new Inbox for an Actor as needed.
+changes to existing deployed ActivityPub servers. In the case where an
+implementation does not understand the new Inbox being offered, they would
+continue to go through a "Default Inbox" route.
 
 ** MultiBox
 
@@ -441,12 +440,17 @@ messages, we would encourage that implementers of this idea be focused on
 like Hashcash are easy to implement, without adding a direct benefit to the
 receiver, they require the sender to expend resources. If extrapolated to a
 large scale, this could have a negative environmental impact due to wasted
-computing resources. It should also be noted that due to currency and cost of
-living differences, any form of fee whether paid directly or indirectly, will
+computing resources.
+
+The issues around "real currency" are far more complex. Issuing a postage fee
+based in actual currency more accurately reflects the cost of handling incoming
+spam and by virtue of requiring actual money, makes sending out mass
+solicitation or scambait email more costly. At the same time, by virtue of cost
+of living differences any form of fee whether paid directly or indirectly, will
 have a correspondingly different financial impact with greater proportional
 cost born by those in poorer countries.
 
-Because of these issues and the spirit of free communication, we would
+Because of these concerns and the spirit of free communication, we would
 encourage any implementation of this technique to be used sparingly and only on
 the first message of a new sender, rather than on all messages.
 

--- a/topics-and-advance-readings/ap-unwanted-messages.org
+++ b/topics-and-advance-readings/ap-unwanted-messages.org
@@ -142,7 +142,7 @@ This act of the sender handing out capabilities may be done in a number of
  "type": "Inbox",
  "to": ["https://chatty.example/ben/"],
  "attributedTo": "https://social.example/alyssa/",
- "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
+ "alternativeInbox ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
 #+END_SRC
 
 In our example, we show multiple inboxes being delivered. As part of the Object

--- a/topics-and-advance-readings/ap-unwanted-messages.org
+++ b/topics-and-advance-readings/ap-unwanted-messages.org
@@ -127,7 +127,7 @@ Without delving too far into the theory of object capabilities, we can imagine
 that the ability to send a message from one Actor to another is an action that
 we can grant explicit access to similarly to the way that access is granted to
 an API in a computer system. In order to be able to send a message to the
-receipient, the recipient must first provide the sender with a /capability/ to
+recipient, the recipient must first provide the sender with a /capability/ to
 do so. This capability can be represented as a long randomly generated string.
 Its length and randomness make it impractical to guess and thus (in OCAP
 parlance) unforgeable.
@@ -142,7 +142,7 @@ This act of the sender handing out capabilities may be done in a number of
  "type": "Inbox",
  "to": ["https://chatty.example/ben/"],
  "attributedTo": "https://social.example/alyssa/",
- "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj]
+ "inboxes": ["https://social.example/dbgxpggrez", "https://social.example/ptmihemlzj"]
 #+END_SRC
 
 In our example, we show multiple inboxes being delivered. As part of the Object
@@ -234,7 +234,7 @@ literature as either /Joe Jobbing/ or /Phishing/.
 
 In Email, verification is largely achieved by verifying that the email server
 is trusted for the domain which it purports to deliver email, often through an
-out of band technique, often involving DNS, such as SPF[fn:1] or DMIM[fn:2].
+out of band technique, often involving DNS, such as SPF[fn:1] or DKIM[fn:2].
 
 In ActivityPub, sender identification is performed at the Actor level using the
 HTTP Signatures.[fn:3] With this extension, each Actor has a public and private


### PR DESCRIPTION
This is a submission for RWoT9 around keeping unwanted messages (spam, etc.) off the ActivityPub Fediverse using a variety of techniques.

If this proposal is too long, I can extract just the Pet Names proposal as a submission. Please let me know!